### PR TITLE
SecuritySpy resilience, admin clip settings, and Telegram UX

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ linters:
       max-complexity: 15
     gocyclo:
       min-complexity: 30
+    gomoddirectives:
+      replace-local: true # local securityspy while developing VideoURL helpers
     gocritic:
       enable-all: true
       # Conflicts with nonamedreturns; unnamed (string, string) pairs are fine.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Optional `[motifini]` settings:
 - `log_files` — number of rotated log files to keep (default `10`)
 - `security_spy_retry` — how often to retry connecting when SecuritySpy is down at startup (Go duration, default `5s`)
 
+Admin Telegram commands:
+
+- `/camset` (aka `/clipset`) — per-camera clip profile used for motion alerts and `/vid` (everyone gets the same clip)
+  - **Scale:** full / half / quarter of native resolution (default half)
+  - **Length:** 2–15 seconds (default 6s)
+  - **Size:** 500k–3MB max file size (default 1.5MB)
+  - Also available from **Cameras → camera → Clip settings** for admins
+
 ## HTTP Endpoints
 
 If you enable the webserver, these are (some) of the endpoints.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Optional `[motifini]` settings:
 - `event_log` — path for a rotating SecuritySpy event-stream log (omit to disable; must differ from `log_file`)
 - `log_file_mb` — max size per rotated log file in MB (default `5`)
 - `log_files` — number of rotated log files to keep (default `10`)
+- `security_spy_retry` — how often to retry connecting when SecuritySpy is down at startup (Go duration, default `5s`)
 
 ## HTTP Endpoints
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Optional `[motifini]` settings:
 - `log_files` — number of rotated log files to keep (default `10`)
 - `security_spy_retry` — how often to retry connecting when SecuritySpy is down at startup (Go duration, default `5s`)
 
+Built-in system events (subscribe via Events / `/sub`):
+
+- **Motifini Started** — text notification when Motifini finishes booting (Telegram ready)
+- Event Stream Up / Down, Camera Online / Offline, SecuritySpy Error
+
 Admin Telegram commands:
 
 - `/camset` (aka `/clipset`) — per-camera clip profile used for motion alerts and `/vid` (everyone gets the same clip)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/davidnewhall/motifini
 go 1.26.5
 
 require (
+	github.com/dromara/carbon/v2 v2.6.16
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/gorilla/mux v1.8.1
 	github.com/spf13/pflag v1.0.10
@@ -10,7 +11,7 @@ require (
 	golift.io/cnfg v0.2.5
 	golift.io/cnfgfile v0.0.0-20240713024420-a5436d84eb48
 	golift.io/rotatorr v0.0.0-20260217050959-f6ac6fc7b38e
-	golift.io/securityspy/v2 v2.1.1-0.20260720201818-773e6c2f3c09
+	golift.io/securityspy/v2 v2.1.1
 	golift.io/subscribe v0.0.0-20260720203740-de586e9886b0
 	golift.io/version v0.0.2
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/bluenviron/mediacommon/v2 v2.9.1 h1:GpNnZgBwAamQO9ZE+JbNkQo82N1Jh/koS
 github.com/bluenviron/mediacommon/v2 v2.9.1/go.mod h1:jMf/OJDaJl02xRgkLM2zbidUHnDYqLnO1dMMveCmyyU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dromara/carbon/v2 v2.6.16 h1:AbxrnW1kJhR3KHdS8G96NFmxDwPFyre+t+xSiJIUD1I=
+github.com/dromara/carbon/v2 v2.6.16/go.mod h1:NGo3reeV5vhWCYWcSqbJRZm46MEwyfYI5EJRdVFoLJo=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
@@ -50,8 +52,8 @@ golift.io/cnfgfile v0.0.0-20240713024420-a5436d84eb48 h1:c7cJWRr0cUnFHKtq072esKz
 golift.io/cnfgfile v0.0.0-20240713024420-a5436d84eb48/go.mod h1:zHm9o8SkZ6Mm5DfGahsrEJPsogyR0qItP59s5lJ98/I=
 golift.io/rotatorr v0.0.0-20260217050959-f6ac6fc7b38e h1:FgfNgbg2EUhFzAWPycsbh1dYiFJNLJFDDkn+E298DFQ=
 golift.io/rotatorr v0.0.0-20260217050959-f6ac6fc7b38e/go.mod h1:l/fgYTDxyEw15tRLjAtc13M3is1SXMU4hAIE0tdduAQ=
-golift.io/securityspy/v2 v2.1.1-0.20260720201818-773e6c2f3c09 h1:5zAMO2yqH9jL8yJUmEGWGNRLWD10Kvi6WeQS6HNXqI8=
-golift.io/securityspy/v2 v2.1.1-0.20260720201818-773e6c2f3c09/go.mod h1:pnDxzbSac8kRy+xxnjy7AJckNs4htQKz1YOAhjdNzaE=
+golift.io/securityspy/v2 v2.1.1 h1:HvY8krx5+LwW3xN80+tva63KGMZgYDjJVOQ6jUPsSIM=
+golift.io/securityspy/v2 v2.1.1/go.mod h1:pnDxzbSac8kRy+xxnjy7AJckNs4htQKz1YOAhjdNzaE=
 golift.io/subscribe v0.0.0-20260720203740-de586e9886b0 h1:YgnIrSnLiz/IPPjkh+cmDdJS0oc5QaNZo4409jzyCqA=
 golift.io/subscribe v0.0.0-20260720203740-de586e9886b0/go.mod h1:ZfzMeNnPbNbCKI4vt8NKtMi1pZpIe+OjpxHjzsgRmuc=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=

--- a/pkg/chat/cameras.go
+++ b/pkg/chat/cameras.go
@@ -25,7 +25,8 @@ func (c *Chat) cameraByName(name string) *securityspy.Camera {
 // noCamerasReply is shown when SecuritySpy has not loaded any cameras yet.
 func (c *Chat) noCamerasReply() *Reply {
 	return &Reply{
-		Reply: "SecuritySpy isn't ready (no cameras loaded).\n\nCheck the [security_spy] config and connection, then try again.",
+		Reply: "SecuritySpy isn't ready (no cameras loaded).\n\n" +
+			"Check the [security_spy] config and connection, then try again.",
 		Edit:  true,
 		Toast: "Offline",
 		Keyboard: [][]Button{

--- a/pkg/chat/cameras.go
+++ b/pkg/chat/cameras.go
@@ -1,0 +1,44 @@
+package chat
+
+import (
+	"golift.io/securityspy/v2"
+)
+
+// allCameras returns SecuritySpy cameras or an empty slice when SS is unavailable.
+func (c *Chat) allCameras() []*securityspy.Camera {
+	if c == nil || c.SSpy == nil || c.SSpy.Cameras == nil {
+		return nil
+	}
+
+	return c.SSpy.Cameras.All()
+}
+
+// cameraByName looks up a camera, or nil when SecuritySpy has no camera list yet.
+func (c *Chat) cameraByName(name string) *securityspy.Camera {
+	if c == nil || c.SSpy == nil || c.SSpy.Cameras == nil {
+		return nil
+	}
+
+	return c.SSpy.Cameras.ByName(name)
+}
+
+// noCamerasReply is shown when SecuritySpy has not loaded any cameras yet.
+func (c *Chat) noCamerasReply() *Reply {
+	return &Reply{
+		Reply: "SecuritySpy isn't connected yet (no cameras loaded).\n\nTry again in a moment.",
+		Edit:  true,
+		Toast: "Offline",
+		Keyboard: [][]Button{
+			{{Label: "Done", Data: cbCancel}},
+		},
+	}
+}
+
+// refreshCameras best-effort refreshes SecuritySpy; safe when SSpy is nil.
+func (c *Chat) refreshCameras() {
+	if c == nil || c.SSpy == nil {
+		return
+	}
+
+	_ = c.SSpy.Refresh()
+}

--- a/pkg/chat/cameras.go
+++ b/pkg/chat/cameras.go
@@ -25,7 +25,7 @@ func (c *Chat) cameraByName(name string) *securityspy.Camera {
 // noCamerasReply is shown when SecuritySpy has not loaded any cameras yet.
 func (c *Chat) noCamerasReply() *Reply {
 	return &Reply{
-		Reply: "SecuritySpy isn't connected yet (no cameras loaded).\n\nTry again in a moment.",
+		Reply: "SecuritySpy isn't ready (no cameras loaded).\n\nCheck the [security_spy] config and connection, then try again.",
 		Edit:  true,
 		Toast: "Offline",
 		Keyboard: [][]Button{

--- a/pkg/chat/cameras.go
+++ b/pkg/chat/cameras.go
@@ -4,7 +4,7 @@ import (
 	"golift.io/securityspy/v2"
 )
 
-// allCameras returns SecuritySpy cameras or an empty slice when SS is unavailable.
+// allCameras returns SecuritySpy cameras, or nil when SS is unavailable.
 func (c *Chat) allCameras() []*securityspy.Camera {
 	if c == nil || c.SSpy == nil || c.SSpy.Cameras == nil {
 		return nil

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -209,6 +209,15 @@ func FormatClipSettings(settings ClipSettings) string {
 		formatByteSize(settings.Size))
 }
 
+// cameraFrameSize returns "WIDTHxHEIGHT" or empty when unknown.
+func cameraFrameSize(cam *securityspy.Camera) string {
+	if cam == nil || cam.Width < 1 || cam.Height < 1 {
+		return ""
+	}
+
+	return fmt.Sprintf("%dx%d", cam.Width, cam.Height)
+}
+
 func scaleLabel(scale string) string {
 	switch scale {
 	case ScaleFull:

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -144,6 +144,10 @@ func allowedClipSizeBytes(size int) bool {
 
 // heightForScale maps full/half/quarter to a request height.
 // Zero means omit height/width (native / full-size stream).
+//
+// SecuritySpy stream-copies native HEVC when requested height is >= half the
+// camera's native height (Mailbox 1440→720 stays 2560x1440; 719/718 recompresses).
+// Half therefore requests strictly below half native, then forces even pixels.
 func heightForScale(nativeHeight int, scale string) int {
 	if nativeHeight < 2 {
 		return 0
@@ -155,7 +159,7 @@ func heightForScale(nativeHeight int, scale string) int {
 	case ScaleQuarter:
 		return evenPixels(nativeHeight / 4)
 	default:
-		return evenPixels(nativeHeight / 2)
+		return evenPixels(nativeHeight/2 - 1)
 	}
 }
 

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -48,7 +48,7 @@ func IsCamSettingsKey(name string) bool {
 	return strings.HasPrefix(name, camSettingsPrefix)
 }
 
-// CatalogEventNames lists subscribeable global events (excludes __cam: settings keys).
+// CatalogEventNames lists subscribable global events (excludes __cam: settings keys).
 func CatalogEventNames(events *subscribe.Events) []string {
 	if events == nil {
 		return nil

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -104,11 +104,11 @@ func GetCameraClipSettings(data *subscribe.Subscribe, camName string) ClipSettin
 	}
 
 	if length, ok := data.Events.RuleGetD(key, ruleLength); ok && length > 0 {
-		settings.Length = length
+		settings.Length = clampClipLength(length)
 	}
 
 	if size, ok := data.Events.RuleGetI(key, ruleSize); ok && size > 0 {
-		settings.Size = size
+		settings.Size = clampClipSize(size)
 	}
 
 	return settings
@@ -121,6 +121,31 @@ func validScale(scale string) bool {
 	default:
 		return false
 	}
+}
+
+func clampClipLength(d time.Duration) time.Duration {
+	secs := int(d.Round(time.Second) / time.Second)
+	if secs < MinClipLengthSecs {
+		secs = MinClipLengthSecs
+	}
+
+	if secs > MaxClipLengthSecs {
+		secs = MaxClipLengthSecs
+	}
+
+	return time.Duration(secs) * time.Second
+}
+
+func clampClipSize(size int) int {
+	if size < MinClipSizeBytes {
+		return MinClipSizeBytes
+	}
+
+	if size > MaxClipSizeBytes {
+		return MaxClipSizeBytes
+	}
+
+	return size
 }
 
 func allowedClipLengthSecs(secs int) bool {

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -1,0 +1,225 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"golift.io/securityspy/v2"
+	"golift.io/subscribe"
+)
+
+// Global catalog keys for admin per-camera clip settings (not subscribeable).
+const (
+	camSettingsPrefix = "__cam:"
+
+	ruleScale  = "scale"
+	ruleLength = "length"
+	ruleSize   = "size"
+
+	ScaleFull    = "full"
+	ScaleHalf    = "half"
+	ScaleQuarter = "quarter"
+
+	DefaultClipScale  = ScaleHalf
+	DefaultClipLength = 6 * time.Second
+	DefaultClipSize   = 1572864 // 1.5 MiB
+)
+
+// ClipSettings is the admin-global capture profile for one camera.
+type ClipSettings struct {
+	Scale  string
+	Length time.Duration
+	Size   int // max file size in bytes
+}
+
+// CamSettingsKey returns the reserved catalog event name for a camera.
+func CamSettingsKey(camName string) string {
+	return camSettingsPrefix + camName
+}
+
+// IsCamSettingsKey reports whether name is a reserved camera-settings catalog entry.
+func IsCamSettingsKey(name string) bool {
+	return strings.HasPrefix(name, camSettingsPrefix)
+}
+
+// CatalogEventNames lists subscribeable global events (excludes __cam: settings keys).
+func CatalogEventNames(events *subscribe.Events) []string {
+	if events == nil {
+		return nil
+	}
+
+	names := events.Names()
+	out := make([]string, 0, len(names))
+
+	for _, name := range names {
+		if IsCamSettingsKey(name) {
+			continue
+		}
+
+		out = append(out, name)
+	}
+
+	return out
+}
+
+// EnsureCameraSettings creates a catalog entry with defaults if missing.
+func EnsureCameraSettings(data *subscribe.Subscribe, camName string) {
+	if data == nil || data.Events == nil || camName == "" {
+		return
+	}
+
+	key := CamSettingsKey(camName)
+	if data.Events.Exists(key) {
+		return
+	}
+
+	_ = data.Events.New(key, &subscribe.Rules{
+		S: map[string]string{ruleScale: DefaultClipScale},
+		D: map[string]time.Duration{ruleLength: DefaultClipLength},
+		I: map[string]int{ruleSize: DefaultClipSize},
+	})
+}
+
+// GetCameraClipSettings returns stored settings or defaults.
+func GetCameraClipSettings(data *subscribe.Subscribe, camName string) ClipSettings {
+	settings := ClipSettings{
+		Scale:  DefaultClipScale,
+		Length: DefaultClipLength,
+		Size:   DefaultClipSize,
+	}
+
+	if data == nil || data.Events == nil || camName == "" {
+		return settings
+	}
+
+	key := CamSettingsKey(camName)
+	if scale, ok := data.Events.RuleGetS(key, ruleScale); ok && validScale(scale) {
+		settings.Scale = scale
+	}
+
+	if length, ok := data.Events.RuleGetD(key, ruleLength); ok && length > 0 {
+		settings.Length = length
+	}
+
+	if size, ok := data.Events.RuleGetI(key, ruleSize); ok && size > 0 {
+		settings.Size = size
+	}
+
+	return settings
+}
+
+func validScale(scale string) bool {
+	switch scale {
+	case ScaleFull, ScaleHalf, ScaleQuarter:
+		return true
+	default:
+		return false
+	}
+}
+
+// heightForScale maps full/half/quarter to a request height.
+// Zero means omit height/width (native / full-size stream).
+func heightForScale(nativeHeight int, scale string) int {
+	if nativeHeight < 2 {
+		return 0
+	}
+
+	switch scale {
+	case ScaleFull:
+		return 0
+	case ScaleQuarter:
+		return evenPixels(nativeHeight / 4)
+	default:
+		return evenPixels(nativeHeight / 2)
+	}
+}
+
+func evenPixels(value int) int {
+	if value < 2 {
+		return 0
+	}
+
+	if value%2 != 0 {
+		value--
+	}
+
+	if value < 2 {
+		return 0
+	}
+
+	return value
+}
+
+// VideoClipOps builds RTSP remux options from admin clip settings.
+// Full scale omits width/height so SecuritySpy can stream-copy native resolution.
+// Half / quarter request even dimensions derived from the camera aspect ratio.
+func VideoClipOps(cam *securityspy.Camera, settings ClipSettings) *securityspy.VidOps {
+	ops := &securityspy.VidOps{ACodec: "aac"}
+	if cam == nil {
+		return ops
+	}
+
+	ops.VCodec = cam.PreferredVCodec()
+
+	height := heightForScale(cam.Height, settings.Scale)
+	ops.Height = height
+
+	if cam.Width > 0 && cam.Height > 0 && height > 0 {
+		width := cam.Width * height / cam.Height
+		ops.Width = evenPixels(width)
+	}
+
+	return ops
+}
+
+// FormatClipSettings summarizes settings for Telegram button labels.
+func FormatClipSettings(settings ClipSettings) string {
+	return fmt.Sprintf("%s · %s · %s",
+		scaleLabel(settings.Scale),
+		formatClipSecs(settings.Length),
+		formatByteSize(settings.Size))
+}
+
+func scaleLabel(scale string) string {
+	switch scale {
+	case ScaleFull:
+		return "full"
+	case ScaleQuarter:
+		return "¼"
+	default:
+		return "½"
+	}
+}
+
+func formatClipSecs(dur time.Duration) string {
+	secs := max(1, int(dur.Round(time.Second)/time.Second))
+
+	return fmt.Sprintf("%ds", secs)
+}
+
+func formatByteSize(bytes int) string {
+	const (
+		bytesPerKB = 1024
+		bytesPerMB = 1024 * 1024
+	)
+
+	if bytes >= bytesPerMB {
+		whole := bytes / bytesPerMB
+		frac := bytes % bytesPerMB
+		if frac == 0 {
+			return fmt.Sprintf("%dMB", whole)
+		}
+
+		// One decimal place (1.2MB, 1.5MB, 2.5MB).
+		tenths := (bytes*10 + bytesPerMB/2) / bytesPerMB
+
+		return fmt.Sprintf("%d.%dMB", tenths/10, tenths%10)
+	}
+
+	if bytes%bytesPerKB == 0 {
+		return fmt.Sprintf("%dk", bytes/bytesPerKB)
+	}
+
+	return fmt.Sprintf("%dB", bytes)
+}

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -9,7 +9,7 @@ import (
 	"golift.io/subscribe"
 )
 
-// Global catalog keys for admin per-camera clip settings (not subscribeable).
+// Global catalog keys for admin per-camera clip settings (not subscribable).
 const (
 	camSettingsPrefix = "__cam:"
 

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -24,6 +24,11 @@ const (
 	DefaultClipScale  = ScaleHalf
 	DefaultClipLength = 6 * time.Second
 	DefaultClipSize   = 1572864 // 1.5 MiB
+
+	MinClipLengthSecs = 2
+	MaxClipLengthSecs = 15
+	MinClipSizeBytes  = 500 * 1024
+	MaxClipSizeBytes  = 3 * 1024 * 1024
 )
 
 // ClipSettings is the admin-global capture profile for one camera.
@@ -116,6 +121,14 @@ func validScale(scale string) bool {
 	default:
 		return false
 	}
+}
+
+func allowedClipLengthSecs(secs int) bool {
+	return secs >= MinClipLengthSecs && secs <= MaxClipLengthSecs
+}
+
+func allowedClipSizeBytes(size int) bool {
+	return size >= MinClipSizeBytes && size <= MaxClipSizeBytes
 }
 
 // heightForScale maps full/half/quarter to a request height.

--- a/pkg/chat/camsettings.go
+++ b/pkg/chat/camsettings.go
@@ -125,27 +125,13 @@ func validScale(scale string) bool {
 
 func clampClipLength(d time.Duration) time.Duration {
 	secs := int(d.Round(time.Second) / time.Second)
-	if secs < MinClipLengthSecs {
-		secs = MinClipLengthSecs
-	}
-
-	if secs > MaxClipLengthSecs {
-		secs = MaxClipLengthSecs
-	}
+	secs = max(MinClipLengthSecs, min(secs, MaxClipLengthSecs))
 
 	return time.Duration(secs) * time.Second
 }
 
 func clampClipSize(size int) int {
-	if size < MinClipSizeBytes {
-		return MinClipSizeBytes
-	}
-
-	if size > MaxClipSizeBytes {
-		return MaxClipSizeBytes
-	}
-
-	return size
+	return max(MinClipSizeBytes, min(size, MaxClipSizeBytes))
 }
 
 func allowedClipLengthSecs(secs int) bool {

--- a/pkg/chat/camsettings_test.go
+++ b/pkg/chat/camsettings_test.go
@@ -15,16 +15,18 @@ func TestHeightForScale(t *testing.T) {
 		t.Fatalf("full: got %d want 0", got)
 	}
 
-	if got := heightForScale(1440, ScaleHalf); got != 720 {
-		t.Fatalf("half 1440: got %d want 720", got)
+	// Mailbox: exact half (720) stream-copies; stay at 718.
+	if got := heightForScale(1440, ScaleHalf); got != 718 {
+		t.Fatalf("half 1440: got %d want 718", got)
 	}
 
 	if got := heightForScale(1440, ScaleQuarter); got != 360 {
 		t.Fatalf("quarter 1440: got %d want 360", got)
 	}
 
-	if got := heightForScale(1728, ScaleHalf); got != 864 {
-		t.Fatalf("half 1728: got %d want 864", got)
+	// Pool 1728: half−1 → 862 (below 864 cliff).
+	if got := heightForScale(1728, ScaleHalf); got != 862 {
+		t.Fatalf("half 1728: got %d want 862", got)
 	}
 
 	if got := heightForScale(1081, ScaleHalf); got%2 != 0 {
@@ -117,6 +119,14 @@ func TestVideoClipOpsScale(t *testing.T) {
 	}
 	if ops.VCodec != "h265" {
 		t.Fatalf("vcodec: got %q", ops.VCodec)
+	}
+
+	half := VideoClipOps(cam, ClipSettings{Scale: ScaleHalf})
+	if half.Height != 718 {
+		t.Fatalf("half height: got %d want 718", half.Height)
+	}
+	if half.Width != 1276 {
+		t.Fatalf("half width: got %d want 1276", half.Width)
 	}
 
 	full := VideoClipOps(cam, ClipSettings{Scale: ScaleFull})

--- a/pkg/chat/camsettings_test.go
+++ b/pkg/chat/camsettings_test.go
@@ -1,0 +1,97 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	"golift.io/securityspy/v2"
+	"golift.io/subscribe"
+)
+
+func TestHeightForScale(t *testing.T) {
+	t.Parallel()
+
+	if got := heightForScale(1440, ScaleFull); got != 0 {
+		t.Fatalf("full: got %d want 0", got)
+	}
+
+	if got := heightForScale(1440, ScaleHalf); got != 720 {
+		t.Fatalf("half 1440: got %d want 720", got)
+	}
+
+	if got := heightForScale(1440, ScaleQuarter); got != 360 {
+		t.Fatalf("quarter 1440: got %d want 360", got)
+	}
+
+	if got := heightForScale(1728, ScaleHalf); got != 864 {
+		t.Fatalf("half 1728: got %d want 864", got)
+	}
+
+	if got := heightForScale(1081, ScaleHalf); got%2 != 0 {
+		t.Fatalf("half odd native: got odd height %d", got)
+	}
+}
+
+func TestGetCameraClipSettingsDefaults(t *testing.T) {
+	t.Parallel()
+
+	got := GetCameraClipSettings(nil, "Office")
+	if got.Scale != DefaultClipScale || got.Length != DefaultClipLength || got.Size != DefaultClipSize {
+		t.Fatalf("defaults: %+v", got)
+	}
+}
+
+func TestCameraClipSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	events := &subscribe.Events{Map: make(map[string]*subscribe.Rules)}
+	data := &subscribe.Subscribe{Events: events}
+
+	EnsureCameraSettings(data, "Mailbox")
+	key := CamSettingsKey("Mailbox")
+	events.RuleSetS(key, ruleScale, ScaleQuarter)
+	events.RuleSetD(key, ruleLength, 10*time.Second)
+	events.RuleSetI(key, ruleSize, 800*1024)
+
+	got := GetCameraClipSettings(data, "Mailbox")
+	if got.Scale != ScaleQuarter || got.Length != 10*time.Second || got.Size != 800*1024 {
+		t.Fatalf("got %+v", got)
+	}
+
+	_ = events.New("Door Bell", nil)
+
+	names := CatalogEventNames(events)
+	foundDoor := false
+	for _, name := range names {
+		if IsCamSettingsKey(name) {
+			t.Fatalf("catalog leaked settings key %q", name)
+		}
+		if name == "Door Bell" {
+			foundDoor = true
+		}
+	}
+	if !foundDoor {
+		t.Fatal("expected Door Bell in catalog names")
+	}
+}
+
+func TestVideoClipOpsScale(t *testing.T) {
+	t.Parallel()
+
+	cam := &securityspy.Camera{Name: "Office", Width: 2560, Height: 1440, VideoFormat: "H.265"}
+	ops := VideoClipOps(cam, ClipSettings{Scale: ScaleQuarter})
+	if ops.Height != 360 {
+		t.Fatalf("height: got %d want 360", ops.Height)
+	}
+	if ops.Width != 640 {
+		t.Fatalf("width: got %d want 640", ops.Width)
+	}
+	if ops.VCodec != "h265" {
+		t.Fatalf("vcodec: got %q", ops.VCodec)
+	}
+
+	full := VideoClipOps(cam, ClipSettings{Scale: ScaleFull})
+	if full.Height != 0 || full.Width != 0 {
+		t.Fatalf("full should omit size: %+v", full)
+	}
+}

--- a/pkg/chat/camsettings_test.go
+++ b/pkg/chat/camsettings_test.go
@@ -41,6 +41,35 @@ func TestGetCameraClipSettingsDefaults(t *testing.T) {
 	}
 }
 
+func TestGetCameraClipSettingsClamps(t *testing.T) {
+	t.Parallel()
+
+	events := &subscribe.Events{Map: make(map[string]*subscribe.Rules)}
+	data := &subscribe.Subscribe{Events: events}
+	EnsureCameraSettings(data, "Office")
+	key := CamSettingsKey("Office")
+	events.RuleSetD(key, ruleLength, 60*time.Second)
+	events.RuleSetI(key, ruleSize, 50*1024*1024)
+
+	got := GetCameraClipSettings(data, "Office")
+	if got.Length != time.Duration(MaxClipLengthSecs)*time.Second {
+		t.Fatalf("length: got %v want %ds", got.Length, MaxClipLengthSecs)
+	}
+	if got.Size != MaxClipSizeBytes {
+		t.Fatalf("size: got %d want %d", got.Size, MaxClipSizeBytes)
+	}
+
+	events.RuleSetD(key, ruleLength, time.Second)
+	events.RuleSetI(key, ruleSize, 100)
+	got = GetCameraClipSettings(data, "Office")
+	if got.Length != time.Duration(MinClipLengthSecs)*time.Second {
+		t.Fatalf("min length: got %v", got.Length)
+	}
+	if got.Size != MinClipSizeBytes {
+		t.Fatalf("min size: got %d", got.Size)
+	}
+}
+
 func TestCameraClipSettingsRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/chat/camsettings_wizard.go
+++ b/pkg/chat/camsettings_wizard.go
@@ -255,15 +255,24 @@ func (c *Chat) camSetWizardApply(payload string) (*Reply, bool) {
 		c.Subs.Events.RuleSetS(key, ruleScale, value)
 	case "l":
 		secs, err := strconv.Atoi(value)
-		if err != nil || secs < 1 {
-			return &Reply{Reply: "Bad length.", Edit: true, Toast: "Error"}, false
+		if err != nil || !allowedClipLengthSecs(secs) {
+			return &Reply{
+				Reply: fmt.Sprintf("Length must be %d–%ds.", MinClipLengthSecs, MaxClipLengthSecs),
+				Edit:  true,
+				Toast: "Error",
+			}, false
 		}
 
 		c.Subs.Events.RuleSetD(key, ruleLength, time.Duration(secs)*time.Second)
 	case "z":
 		size, err := strconv.Atoi(value)
-		if err != nil || size < 1 {
-			return &Reply{Reply: "Bad size.", Edit: true, Toast: "Error"}, false
+		if err != nil || !allowedClipSizeBytes(size) {
+			return &Reply{
+				Reply: fmt.Sprintf("Size must be %s–%s.",
+					formatByteSize(MinClipSizeBytes), formatByteSize(MaxClipSizeBytes)),
+				Edit:  true,
+				Toast: "Error",
+			}, false
 		}
 
 		c.Subs.Events.RuleSetI(key, ruleSize, size)

--- a/pkg/chat/camsettings_wizard.go
+++ b/pkg/chat/camsettings_wizard.go
@@ -82,7 +82,11 @@ func (c *Chat) camSetWizardRoot() *Reply {
 	for idx, cam := range cams {
 		settings := GetCameraClipSettings(c.Subs, cam.Name)
 		summary := FormatClipSettings(settings)
-		fmt.Fprintf(&msg, "• %s — %s\n", cam.Name, summary)
+		fmt.Fprintf(&msg, "• %s — %s", cam.Name, summary)
+		if frame := cameraFrameSize(cam); frame != "" {
+			fmt.Fprintf(&msg, " (%s)", frame)
+		}
+		msg.WriteByte('\n')
 		rows = append(rows, []Button{{
 			Label: fmt.Sprintf("%s (%s)", cam.Name, summary),
 			Data:  fmt.Sprintf("k:%d", idx),
@@ -103,10 +107,14 @@ func (c *Chat) camSetWizardCam(idxStr string) *Reply {
 
 	cam := cams[idx]
 	settings := GetCameraClipSettings(c.Subs, cam.Name)
+	current := FormatClipSettings(settings)
+	if frame := cameraFrameSize(cam); frame != "" {
+		current += " (" + frame + ")"
+	}
 
 	return &Reply{
 		Reply: fmt.Sprintf("%s clip settings\n\nCurrent: %s\n\nChoose what to change:",
-			cam.Name, FormatClipSettings(settings)),
+			cam.Name, current),
 		Edit: true,
 		Keyboard: [][]Button{
 			{

--- a/pkg/chat/camsettings_wizard.go
+++ b/pkg/chat/camsettings_wizard.go
@@ -1,0 +1,282 @@
+package chat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Admin per-camera clip settings wizard (Telegram ≤64-byte callbacks).
+//
+// k              → camera list
+// k:{idx}        → camera menu (scale / length / size)
+// k:{idx}:s      → scale presets
+// k:{idx}:l      → length presets
+// k:{idx}:z      → size presets
+// k:{idx}:s:half → apply scale
+// k:{idx}:l:6    → apply length (seconds)
+// k:{idx}:z:N    → apply size (bytes)
+
+func (c *Chat) handleCamSetWizardCallback(handler *Handler, data string) (*Reply, bool, bool) {
+	if data != cbCamSetRoot && !strings.HasPrefix(data, "k:") {
+		return nil, false, false
+	}
+
+	if handler == nil || handler.Sub == nil || !handler.Sub.Admin {
+		return &Reply{Reply: "Admins only.", Edit: true, Toast: "Nope"}, false, true
+	}
+
+	if data == cbCamSetRoot {
+		return c.camSetWizardRoot(), false, true
+	}
+
+	payload := strings.TrimPrefix(data, "k:")
+	parts := strings.Split(payload, ":")
+
+	switch len(parts) {
+	case 1:
+		return c.camSetWizardCam(parts[0]), false, true
+	case 2:
+		return c.camSetWizardKind(parts[0], parts[1]), false, true
+	case 3:
+		reply, save := c.camSetWizardApply(payload)
+
+		return reply, save, true
+	default:
+		return &Reply{Reply: "Bad clip-settings pick.", Edit: true, Toast: "Error"}, false, true
+	}
+}
+
+func (c *Chat) camSetWizardKind(idxStr, kind string) *Reply {
+	switch kind {
+	case "s":
+		return c.camSetWizardScale(idxStr)
+	case "l":
+		return c.camSetWizardLength(idxStr)
+	case "z":
+		return c.camSetWizardSize(idxStr)
+	default:
+		return &Reply{Reply: "Bad clip-settings pick.", Edit: true, Toast: "Error"}
+	}
+}
+
+func (c *Chat) cmdCamSet(_ *Handler) (*Reply, error) {
+	root := c.camSetWizardRoot()
+	root.Edit = false
+
+	return root, nil
+}
+
+func (c *Chat) camSetWizardRoot() *Reply {
+	c.refreshCameras()
+	cams := c.allCameras()
+	if len(cams) == 0 {
+		return c.noCamerasReply()
+	}
+
+	rows := make([][]Button, 0, len(cams)+1)
+	var msg strings.Builder
+	msg.WriteString("Per-camera clip settings (everyone gets the same clip).\n\n")
+
+	for idx, cam := range cams {
+		settings := GetCameraClipSettings(c.Subs, cam.Name)
+		summary := FormatClipSettings(settings)
+		fmt.Fprintf(&msg, "• %s — %s\n", cam.Name, summary)
+		rows = append(rows, []Button{{
+			Label: fmt.Sprintf("%s (%s)", cam.Name, summary),
+			Data:  fmt.Sprintf("k:%d", idx),
+		}})
+	}
+
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
+
+	return &Reply{Reply: msg.String(), Edit: true, Keyboard: rows}
+}
+
+func (c *Chat) camSetWizardCam(idxStr string) *Reply {
+	idx := atoiDefault(idxStr, -1)
+	cams := c.allCameras()
+	if idx < 0 || idx >= len(cams) {
+		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}
+	}
+
+	cam := cams[idx]
+	settings := GetCameraClipSettings(c.Subs, cam.Name)
+
+	return &Reply{
+		Reply: fmt.Sprintf("%s clip settings\n\nCurrent: %s\n\nChoose what to change:",
+			cam.Name, FormatClipSettings(settings)),
+		Edit: true,
+		Keyboard: [][]Button{
+			{
+				{Label: "Scale", Data: fmt.Sprintf("k:%d:s", idx)},
+				{Label: "Length", Data: fmt.Sprintf("k:%d:l", idx)},
+				{Label: "Size", Data: fmt.Sprintf("k:%d:z", idx)},
+			},
+			{{Label: "« Cameras", Data: cbCamSetRoot}, {Label: "Done", Data: cbCancel}},
+		},
+	}
+}
+
+func (c *Chat) camSetWizardScale(idxStr string) *Reply {
+	idx := atoiDefault(idxStr, -1)
+	cams := c.allCameras()
+	if idx < 0 || idx >= len(cams) {
+		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}
+	}
+
+	return &Reply{
+		Reply: "Video scale relative to the camera's native resolution.\n\n" +
+			"Full = native (may stream-copy HEVC).\n" +
+			"Half = ½ height.\n" +
+			"Quarter = ¼ height (smaller files, usually recompressed).",
+		Edit: true,
+		Keyboard: [][]Button{
+			{
+				{Label: "Full", Data: fmt.Sprintf("k:%d:s:%s", idx, ScaleFull)},
+				{Label: "Half", Data: fmt.Sprintf("k:%d:s:%s", idx, ScaleHalf)},
+				{Label: "Quarter", Data: fmt.Sprintf("k:%d:s:%s", idx, ScaleQuarter)},
+			},
+			{{Label: "« Back", Data: fmt.Sprintf("k:%d", idx)}, {Label: "Done", Data: cbCancel}},
+		},
+	}
+}
+
+func (c *Chat) camSetWizardLength(idxStr string) *Reply {
+	idx := atoiDefault(idxStr, -1)
+	cams := c.allCameras()
+	if idx < 0 || idx >= len(cams) {
+		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}
+	}
+
+	secs := []int{2, 3, 4, 5, 6, 8, 10, 15}
+	rows := make([][]Button, 0, 4)
+	row := make([]Button, 0, 4)
+
+	for _, sec := range secs {
+		row = append(row, Button{
+			Label: fmt.Sprintf("%ds", sec),
+			Data:  fmt.Sprintf("k:%d:l:%d", idx, sec),
+		})
+		if len(row) == 4 {
+			rows = append(rows, row)
+			row = nil
+		}
+	}
+	if len(row) > 0 {
+		rows = append(rows, row)
+	}
+
+	rows = append(rows, []Button{
+		{Label: "« Back", Data: fmt.Sprintf("k:%d", idx)},
+		{Label: "Done", Data: cbCancel},
+	})
+
+	return &Reply{
+		Reply:    "Max clip length (capture stops earlier if the size limit is hit first).",
+		Edit:     true,
+		Keyboard: rows,
+	}
+}
+
+func (c *Chat) camSetWizardSize(idxStr string) *Reply {
+	idx := atoiDefault(idxStr, -1)
+	cams := c.allCameras()
+	if idx < 0 || idx >= len(cams) {
+		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}
+	}
+
+	sizes := []int{
+		500 * 1024,
+		600 * 1024,
+		800 * 1024,
+		1 * 1024 * 1024,
+		1200 * 1024,
+		1572864,
+		2 * 1024 * 1024,
+		2560 * 1024,
+		3 * 1024 * 1024,
+	}
+	rows := make([][]Button, 0, 4)
+	row := make([]Button, 0, 3)
+
+	for _, size := range sizes {
+		row = append(row, Button{
+			Label: formatByteSize(size),
+			Data:  fmt.Sprintf("k:%d:z:%d", idx, size),
+		})
+		if len(row) == 3 {
+			rows = append(rows, row)
+			row = nil
+		}
+	}
+	if len(row) > 0 {
+		rows = append(rows, row)
+	}
+
+	rows = append(rows, []Button{
+		{Label: "« Back", Data: fmt.Sprintf("k:%d", idx)},
+		{Label: "Done", Data: cbCancel},
+	})
+
+	return &Reply{
+		Reply:    "Max clip file size (capture stops when this is reached).",
+		Edit:     true,
+		Keyboard: rows,
+	}
+}
+
+func (c *Chat) camSetWizardApply(payload string) (*Reply, bool) {
+	parts := strings.Split(payload, ":")
+	if len(parts) != 3 {
+		return &Reply{Reply: "Bad clip-settings pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	idx := atoiDefault(parts[0], -1)
+	kind := parts[1]
+	value := parts[2]
+	cams := c.allCameras()
+
+	if idx < 0 || idx >= len(cams) {
+		return &Reply{Reply: "Camera gone.", Edit: true, Toast: "Missing"}, false
+	}
+
+	cam := cams[idx]
+	EnsureCameraSettings(c.Subs, cam.Name)
+	key := CamSettingsKey(cam.Name)
+
+	switch kind {
+	case "s":
+		if !validScale(value) {
+			return &Reply{Reply: "Bad scale.", Edit: true, Toast: "Error"}, false
+		}
+
+		c.Subs.Events.RuleSetS(key, ruleScale, value)
+	case "l":
+		secs, err := strconv.Atoi(value)
+		if err != nil || secs < 1 {
+			return &Reply{Reply: "Bad length.", Edit: true, Toast: "Error"}, false
+		}
+
+		c.Subs.Events.RuleSetD(key, ruleLength, time.Duration(secs)*time.Second)
+	case "z":
+		size, err := strconv.Atoi(value)
+		if err != nil || size < 1 {
+			return &Reply{Reply: "Bad size.", Edit: true, Toast: "Error"}, false
+		}
+
+		c.Subs.Events.RuleSetI(key, ruleSize, size)
+	default:
+		return &Reply{Reply: "Bad clip-settings pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	settings := GetCameraClipSettings(c.Subs, cam.Name)
+	next := c.camSetWizardCam(strconv.Itoa(idx))
+	next.Reply = fmt.Sprintf("Updated %s → %s\n\n", cam.Name, FormatClipSettings(settings)) +
+		fmt.Sprintf("%s clip settings\n\nCurrent: %s\n\nChoose what to change:",
+			cam.Name, FormatClipSettings(settings))
+	next.Toast = "Saved"
+
+	return next, true
+}

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -129,7 +129,8 @@ func (c *Chat) HandleCommand(handler *Handler) *Reply {
 }
 
 func (c *Chat) commandReady(handler *Handler) bool {
-	return c.Subs != nil && c.SSpy != nil && c.TempDir != "" &&
+	// SSpy may be nil when [security_spy] is missing; camera cmds use allCameras()/cameraByName().
+	return c.Subs != nil && c.TempDir != "" &&
 		handler != nil && handler.Sub != nil && !handler.Sub.Ignored && handler.Text != nil
 }
 
@@ -150,7 +151,7 @@ func (c *Chat) applyPendingRename(handler *Handler) *Reply {
 
 // HandleCallback routes inline-keyboard presses (messenger-agnostic callback_data).
 func (c *Chat) HandleCallback(handler *Handler) *Reply {
-	if c.Subs == nil || c.SSpy == nil || handler == nil || handler.Sub == nil || handler.Sub.Ignored {
+	if c.Subs == nil || handler == nil || handler.Sub == nil || handler.Sub.Ignored {
 		return &Reply{}
 	}
 

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -5,6 +5,8 @@ package chat
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +31,9 @@ type Chat struct {
 	SSpy    *securityspy.Server
 	TempDir string
 	Cmds    []*Commands
+	Info    *log.Logger
+	Debug   *log.Logger
+	Error   *log.Logger
 }
 
 // ErrBadUsage is a standard error.
@@ -80,6 +85,18 @@ type Handler struct {
 func New(chatCfg *Chat) *Chat {
 	if chatCfg.TempDir == "" {
 		chatCfg.TempDir = "/tmp"
+	}
+
+	if chatCfg.Info == nil {
+		chatCfg.Info = log.New(io.Discard, "", 0)
+	}
+
+	if chatCfg.Debug == nil {
+		chatCfg.Debug = log.New(io.Discard, "", 0)
+	}
+
+	if chatCfg.Error == nil {
+		chatCfg.Error = log.New(io.Discard, "", 0)
 	}
 
 	defaults := make([]*Commands, 0, 2+len(chatCfg.Cmds)) //nolint:mnd // commands below....

--- a/pkg/chat/commands_admin.go
+++ b/pkg/chat/commands_admin.go
@@ -32,6 +32,12 @@ func (c *Chat) adminCommands() *Commands { //nolint:funlen // it's not that bad.
 				Desc: "Saves subscriber data to a file.",
 			},
 			{
+				Run:  c.cmdCamSet,
+				AKA:  []string{"camset", "clipset", "camsettings"},
+				Desc: "Per-camera clip settings (scale, length, size) for everyone.",
+				Save: false,
+			},
+			{
 				Run:  c.cmdAdminUsers,
 				AKA:  []string{"users", "manage", "people"},
 				Desc: "Manage subscribers — allow, deny, ignore, admin, delete.",

--- a/pkg/chat/commands_admin.go
+++ b/pkg/chat/commands_admin.go
@@ -177,11 +177,12 @@ func (c *Chat) cmdAdminSubs(handler *Handler) (*Reply, error) {
 	fmt.Fprintf(&msg, "%s%s has %d subscriptions:", subscriberDisplayName(subscriber), status, len(subs))
 
 	for i, event := range subs {
-		fmt.Fprintf(&msg, "\n%d: %s · every %v", i+1, formatSubLabel(event), eventDelay(subscriber.Events, event))
+		delay := formatDuration(eventDelay(subscriber.Events, event))
+		fmt.Fprintf(&msg, "\n%d: %s · every %s", i+1, formatSubLabel(event), delay)
 
 		if subscriber.Events.IsPaused(event) {
-			until := time.Until(subscriber.Events.PauseTime(event)).Round(time.Second)
-			fmt.Fprintf(&msg, " (paused %v)", until)
+			until := time.Until(subscriber.Events.PauseTime(event))
+			fmt.Fprintf(&msg, " (paused %s)", formatDuration(until))
 		}
 	}
 

--- a/pkg/chat/commands_nonadmin.go
+++ b/pkg/chat/commands_nonadmin.go
@@ -132,12 +132,59 @@ func (c *Chat) cmdPics(handler *Handler) (*Reply, error) {
 }
 
 func clipVidOps(cam *securityspy.Camera) *securityspy.VidOps {
-	return &securityspy.VidOps{
-		Height:  height,
-		Quality: quality,
-		ACodec:  "aac",
-		VCodec:  cam.PreferredVCodec(),
+	ops := VideoClipOps(cam, height)
+	ops.Quality = quality // JPEG only; stripped from RTSP by securityspy
+
+	return ops
+}
+
+// VideoClipOps builds RTSP remux options using the camera's native codec, scaled to targetHeight.
+// Width is derived from the camera aspect ratio.
+//
+// SecuritySpy stream-copies native HEVC (ignoring height) when the requested height is
+// >= half the camera's native height — e.g. a camera with 1440p (2560x1440) stays 2560x1440 at height=720,
+// but recompresses at height=719. A camera with 1728p (2560x1728) still scales at 720 because 720 < 864.
+func VideoClipOps(cam *securityspy.Camera, targetHeight int) *securityspy.VidOps {
+	ops := &securityspy.VidOps{
+		Height: targetHeight,
+		ACodec: "aac",
 	}
+	if cam == nil {
+		return ops
+	}
+
+	ops.VCodec = cam.PreferredVCodec()
+	ops.Height = scaledStreamHeight(cam.Height, targetHeight)
+
+	if cam.Width > 0 && cam.Height > 0 && ops.Height > 0 {
+		w := cam.Width * ops.Height / cam.Height
+		ops.Width = w - w%2 // encoder-friendly even width
+	}
+
+	return ops
+}
+
+// scaledStreamHeight keeps the request strictly below half the native height so
+// SecuritySpy recompresses HEVC instead of stream-copying the main stream.
+func scaledStreamHeight(nativeHeight, targetHeight int) int {
+	if targetHeight < 2 {
+		return targetHeight
+	}
+
+	height := targetHeight
+	if nativeHeight > 0 && height*2 >= nativeHeight {
+		height = nativeHeight/2 - 1
+	}
+
+	if height%2 != 0 {
+		height--
+	}
+
+	if height < 2 {
+		return targetHeight
+	}
+
+	return height
 }
 
 func (c *Chat) cmdVids(handler *Handler) (*Reply, error) {
@@ -320,5 +367,6 @@ func (c *Chat) cmdDelay(handler *Handler) (*Reply, error) {
 
 	handler.Sub.Events.RuleSetD(event, "delay", time.Duration(dur)*time.Second)
 
-	return &Reply{Reply: fmt.Sprintf("Set repeat delay for '%s' to %ds", event, dur)}, nil
+	return &Reply{Reply: fmt.Sprintf("Set repeat delay for '%s' to %s",
+		event, formatDuration(time.Duration(dur)*time.Second))}, nil
 }

--- a/pkg/chat/commands_nonadmin.go
+++ b/pkg/chat/commands_nonadmin.go
@@ -16,9 +16,6 @@ const (
 )
 
 const (
-	maxsize    = 1024 * 1024 // 1mb
-	length     = 5 * time.Second
-	height     = 720 // SS RTSP resize; 800 often stalls to ~1fps under load
 	jpegHeight = 1080
 	quality    = 20 // JPEG only; stripped from RTSP by securityspy
 )
@@ -110,7 +107,7 @@ func (c *Chat) cmdEvents(_ *Handler) (*Reply, error) {
 func (c *Chat) cmdPics(handler *Handler) (*Reply, error) {
 	if len(handler.Text) > 1 {
 		name := strings.Join(handler.Text[1:], " ")
-		cam := c.SSpy.Cameras.ByName(name)
+		cam := c.cameraByName(name)
 
 		if cam == nil {
 			return &Reply{Reply: "Unknown Camera: " + name}, ErrBadUsage
@@ -131,66 +128,23 @@ func (c *Chat) cmdPics(handler *Handler) (*Reply, error) {
 	return root, nil
 }
 
-func clipVidOps(cam *securityspy.Camera) *securityspy.VidOps {
-	ops := VideoClipOps(cam, height)
+func (c *Chat) clipVidOps(cam *securityspy.Camera) (*securityspy.VidOps, ClipSettings) {
+	name := ""
+	if cam != nil {
+		name = cam.Name
+	}
+
+	settings := GetCameraClipSettings(c.Subs, name)
+	ops := VideoClipOps(cam, settings)
 	ops.Quality = quality // JPEG only; stripped from RTSP by securityspy
 
-	return ops
-}
-
-// VideoClipOps builds RTSP remux options using the camera's native codec, scaled to targetHeight.
-// Width is derived from the camera aspect ratio.
-//
-// SecuritySpy stream-copies native HEVC (ignoring height) when the requested height is
-// >= half the camera's native height — e.g. a camera with 1440p (2560x1440) stays 2560x1440 at height=720,
-// but recompresses at height=719. A camera with 1728p (2560x1728) still scales at 720 because 720 < 864.
-func VideoClipOps(cam *securityspy.Camera, targetHeight int) *securityspy.VidOps {
-	ops := &securityspy.VidOps{
-		Height: targetHeight,
-		ACodec: "aac",
-	}
-	if cam == nil {
-		return ops
-	}
-
-	ops.VCodec = cam.PreferredVCodec()
-	ops.Height = scaledStreamHeight(cam.Height, targetHeight)
-
-	if cam.Width > 0 && cam.Height > 0 && ops.Height > 0 {
-		w := cam.Width * ops.Height / cam.Height
-		ops.Width = w - w%2 // encoder-friendly even width
-	}
-
-	return ops
-}
-
-// scaledStreamHeight keeps the request strictly below half the native height so
-// SecuritySpy recompresses HEVC instead of stream-copying the main stream.
-func scaledStreamHeight(nativeHeight, targetHeight int) int {
-	if targetHeight < 2 {
-		return targetHeight
-	}
-
-	height := targetHeight
-	if nativeHeight > 0 && height*2 >= nativeHeight {
-		height = nativeHeight/2 - 1
-	}
-
-	if height%2 != 0 {
-		height--
-	}
-
-	if height < 2 {
-		return targetHeight
-	}
-
-	return height
+	return ops, settings
 }
 
 func (c *Chat) cmdVids(handler *Handler) (*Reply, error) {
 	if len(handler.Text) > 1 {
 		name := strings.Join(handler.Text[1:], " ")
-		cam := c.SSpy.Cameras.ByName(name)
+		cam := c.cameraByName(name)
 
 		if cam == nil {
 			return &Reply{Reply: "Unknown Camera: " + name}, ErrBadUsage

--- a/pkg/chat/subkeys_test.go
+++ b/pkg/chat/subkeys_test.go
@@ -16,6 +16,7 @@ func TestFormatDuration(t *testing.T) {
 		want string
 	}{
 		{0, "0 seconds"},
+		{-3 * time.Second, "0 seconds"},
 		{500 * time.Millisecond, "0 seconds"},
 		{59*time.Second + 700*time.Millisecond, "1 minute"},
 		{time.Minute, "1 minute"},

--- a/pkg/chat/subkeys_test.go
+++ b/pkg/chat/subkeys_test.go
@@ -15,6 +15,8 @@ func TestFormatDuration(t *testing.T) {
 		d    time.Duration
 		want string
 	}{
+		{0, "0 seconds"},
+		{500 * time.Millisecond, "0 seconds"},
 		{time.Minute, "1 minute"},
 		{2 * time.Minute, "2 minutes"},
 		{30 * time.Second, "30 seconds"},

--- a/pkg/chat/subkeys_test.go
+++ b/pkg/chat/subkeys_test.go
@@ -17,6 +17,7 @@ func TestFormatDuration(t *testing.T) {
 	}{
 		{0, "0 seconds"},
 		{500 * time.Millisecond, "0 seconds"},
+		{59*time.Second + 700*time.Millisecond, "1 minute"},
 		{time.Minute, "1 minute"},
 		{2 * time.Minute, "2 minutes"},
 		{30 * time.Second, "30 seconds"},

--- a/pkg/chat/subkeys_test.go
+++ b/pkg/chat/subkeys_test.go
@@ -8,20 +8,6 @@ import (
 	"golift.io/subscribe"
 )
 
-func TestScaledStreamHeight(t *testing.T) {
-	t.Parallel()
-
-	// Mailbox 1440: 720 is exactly half → SS passthrough; stay at 718.
-	if got := scaledStreamHeight(1440, 720); got != 718 {
-		t.Fatalf("mailbox: got %d want 718", got)
-	}
-
-	// Pool 1728: 720 is below half (864) → keep 720.
-	if got := scaledStreamHeight(1728, 720); got != 720 {
-		t.Fatalf("pool: got %d want 720", got)
-	}
-}
-
 func TestFormatDuration(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/chat/subkeys_test.go
+++ b/pkg/chat/subkeys_test.go
@@ -8,6 +8,39 @@ import (
 	"golift.io/subscribe"
 )
 
+func TestScaledStreamHeight(t *testing.T) {
+	t.Parallel()
+
+	// Mailbox 1440: 720 is exactly half → SS passthrough; stay at 718.
+	if got := scaledStreamHeight(1440, 720); got != 718 {
+		t.Fatalf("mailbox: got %d want 718", got)
+	}
+
+	// Pool 1728: 720 is below half (864) → keep 720.
+	if got := scaledStreamHeight(1728, 720); got != 720 {
+		t.Fatalf("pool: got %d want 720", got)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{time.Minute, "1 minute"},
+		{2 * time.Minute, "2 minutes"},
+		{30 * time.Second, "30 seconds"},
+		{time.Hour, "1 hour"},
+	}
+	for _, tc := range cases {
+		if got := formatDuration(tc.d); got != tc.want {
+			t.Fatalf("%v: got %q want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
 func TestCameraSubKey(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/chat/sysevents.go
+++ b/pkg/chat/sysevents.go
@@ -4,6 +4,7 @@ import "golift.io/subscribe"
 
 // Built-in non-camera system events users can subscribe to.
 const (
+	EventStarted       = "Motifini Started"
 	EventStreamDown    = "Event Stream Down"
 	EventStreamUp      = "Event Stream Up"
 	EventCameraOffline = "Camera Offline"
@@ -20,6 +21,10 @@ type BuiltInEvent struct {
 // BuiltInEvents are registered at startup so they appear in the Event subscribe wizard.
 func BuiltInEvents() []BuiltInEvent {
 	return []BuiltInEvent{
+		{
+			Name: EventStarted,
+			Desc: "Motifini finished starting (Telegram is ready)",
+		},
 		{
 			Name: EventStreamDown,
 			Desc: "Motifini lost the live link to SecuritySpy (no motion alerts until it reconnects)",

--- a/pkg/chat/wizard.go
+++ b/pkg/chat/wizard.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dromara/carbon/v2"
 	"golift.io/subscribe"
 )
 
@@ -79,7 +80,7 @@ func (c *Chat) subWizardRoot() *Reply {
 		Edit: true,
 		Keyboard: [][]Button{
 			{{Label: "Camera", Data: cbSubCam}, {Label: "Event", Data: cbSubEvt}},
-			{{Label: "Cancel", Data: cbCancel}},
+			{{Label: "Done", Data: cbCancel}},
 		},
 	}
 }
@@ -99,7 +100,7 @@ func (c *Chat) subWizardClasses() *Reply {
 				{Label: "Vehicle", Data: cbSubClass + classShort(ClassVehicle)},
 				{Label: "Animal", Data: cbSubClass + classShort(ClassAnimal)},
 			},
-			{{Label: "« Back", Data: cbSubRoot}, {Label: "Cancel", Data: cbCancel}},
+			{{Label: "« Back", Data: cbSubRoot}, {Label: "Done", Data: cbCancel}},
 		},
 	}
 }
@@ -142,7 +143,7 @@ func (c *Chat) subWizardCameras(handler *Handler, classShortCode string) *Reply 
 
 	rows = append(rows, []Button{
 		{Label: "« Back", Data: cbSubCam},
-		{Label: "Cancel", Data: cbCancel},
+		{Label: "Done", Data: cbCancel},
 	})
 
 	return &Reply{
@@ -178,7 +179,7 @@ func (c *Chat) subWizardEvents() *Reply {
 
 	rows = append(rows, []Button{
 		{Label: "« Back", Data: cbSubRoot},
-		{Label: "Cancel", Data: cbCancel},
+		{Label: "Done", Data: cbCancel},
 	})
 
 	return &Reply{
@@ -284,7 +285,7 @@ func (c *Chat) unsubWizardRoot(handler *Handler) *Reply {
 
 	rows = append(rows, []Button{
 		{Label: "Unsubscribe all", Data: "u:*"},
-		{Label: "Cancel", Data: cbCancel},
+		{Label: "Done", Data: cbCancel},
 	})
 
 	return &Reply{
@@ -366,6 +367,28 @@ func eventDelay(events *subscribe.Events, event string) time.Duration {
 	}
 
 	return DefaultRepeatDelay
+}
+
+// formatDuration turns a duration into a Telegram-friendly phrase via carbon
+// (e.g. "1 minute" instead of "1m0s").
+func formatDuration(dur time.Duration) string {
+	if dur < 0 {
+		dur = -dur
+	}
+
+	if dur < time.Second {
+		return "just now"
+	}
+
+	now := carbon.Now()
+	past := carbon.CreateFromStdTime(time.Now().Add(-dur))
+	phrase := past.DiffInString(now)
+
+	if phrase == "" {
+		return "just now"
+	}
+
+	return strings.TrimPrefix(phrase, "-")
 }
 
 // resolveSubTarget turns /sub args into a subscription key and kind label.

--- a/pkg/chat/wizard.go
+++ b/pkg/chat/wizard.go
@@ -377,7 +377,8 @@ func eventDelay(events *subscribe.Events, event string) time.Duration {
 // (e.g. "1 minute" instead of "1m0s").
 func formatDuration(dur time.Duration) string {
 	if dur < 0 {
-		dur = -dur
+		// Countdowns (time.Until) should show "0 seconds" once expired, not abs(dur).
+		return "0 seconds"
 	}
 
 	if dur < time.Second {

--- a/pkg/chat/wizard.go
+++ b/pkg/chat/wizard.go
@@ -111,7 +111,11 @@ func (c *Chat) subWizardCameras(handler *Handler, classShortCode string) *Reply 
 		return c.subWizardClasses()
 	}
 
-	cams := c.SSpy.Cameras.All()
+	cams := c.allCameras()
+	if len(cams) == 0 {
+		return c.noCamerasReply()
+	}
+
 	rows := make([][]Button, 0, len(cams)/2+2)
 
 	var sub *subscribe.Subscriber
@@ -158,7 +162,7 @@ func (c *Chat) subWizardCameras(handler *Handler, classShortCode string) *Reply 
 }
 
 func (c *Chat) subWizardEvents() *Reply {
-	names := c.Subs.Events.Names()
+	names := CatalogEventNames(c.Subs.Events)
 	rows := make([][]Button, 0, len(names)+1)
 
 	for i, name := range names {
@@ -200,7 +204,7 @@ func (c *Chat) subWizardSubscribeCam(handler *Handler, payload string) (*Reply, 
 		return &Reply{Reply: "Bad camera index.", Edit: true, Toast: "Error"}, false
 	}
 
-	cams := c.SSpy.Cameras.All()
+	cams := c.allCameras()
 	if idx < 0 || idx >= len(cams) {
 		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}, false
 	}
@@ -234,7 +238,7 @@ func (c *Chat) subWizardSubscribeEvt(handler *Handler, idxStr string) (*Reply, b
 		return &Reply{Reply: "Bad event index.", Edit: true, Toast: "Error"}, false
 	}
 
-	names := c.Subs.Events.Names()
+	names := CatalogEventNames(c.Subs.Events)
 	if idx < 0 || idx >= len(names) {
 		return &Reply{Reply: "Event gone — try again.", Edit: true, Toast: "Missing"}, false
 	}
@@ -380,8 +384,9 @@ func formatDuration(dur time.Duration) string {
 		return "just now"
 	}
 
-	now := carbon.Now()
-	past := carbon.CreateFromStdTime(time.Now().Add(-dur))
+	base := time.Now()
+	now := carbon.CreateFromStdTime(base)
+	past := carbon.CreateFromStdTime(base.Add(-dur))
 	phrase := past.DiffInString(now)
 
 	if phrase == "" {
@@ -403,11 +408,11 @@ func (c *Chat) resolveSubTarget(args []string) (string, string, error) {
 		return key, kind, err
 	}
 
-	if c.Subs.Events.Exists(joined) {
+	if c.Subs.Events.Exists(joined) && !IsCamSettingsKey(joined) {
 		return joined, "event", nil
 	}
 
-	if cam := c.SSpy.Cameras.ByName(joined); cam != nil {
+	if cam := c.cameraByName(joined); cam != nil {
 		return "", "", fmt.Errorf("%w: specify a class for %s (motion|human|vehicle|animal)", ErrBadUsage, cam.Name)
 	}
 
@@ -422,7 +427,7 @@ func (c *Chat) resolveCameraClassTarget(args []string, joined string) (string, s
 			return "", "", fmt.Errorf("%w: choose motion, human, vehicle, or animal", ErrBadUsage)
 		}
 
-		if cam := c.SSpy.Cameras.ByName(camName); cam != nil {
+		if cam := c.cameraByName(camName); cam != nil {
 			return CameraSubKey(cam.Name, class), "camera", nil
 		}
 	}
@@ -437,7 +442,7 @@ func (c *Chat) resolveCameraClassTarget(args []string, joined string) (string, s
 		return "", "", fmt.Errorf("%w: choose motion, human, vehicle, or animal", ErrBadUsage)
 	}
 
-	if cam := c.SSpy.Cameras.ByName(camName); cam != nil {
+	if cam := c.cameraByName(camName); cam != nil {
 		return CameraSubKey(cam.Name, class), "camera", nil
 	}
 

--- a/pkg/chat/wizard.go
+++ b/pkg/chat/wizard.go
@@ -384,6 +384,9 @@ func formatDuration(dur time.Duration) string {
 		return "0 seconds"
 	}
 
+	// Whole seconds so pause countdowns stay stable near minute boundaries.
+	dur = dur.Round(time.Second)
+
 	base := time.Now()
 	now := carbon.CreateFromStdTime(base)
 	past := carbon.CreateFromStdTime(base.Add(-dur))

--- a/pkg/chat/wizard.go
+++ b/pkg/chat/wizard.go
@@ -381,7 +381,7 @@ func formatDuration(dur time.Duration) string {
 	}
 
 	if dur < time.Second {
-		return "just now"
+		return "0 seconds"
 	}
 
 	base := time.Now()
@@ -390,7 +390,7 @@ func formatDuration(dur time.Duration) string {
 	phrase := past.DiffInString(now)
 
 	if phrase == "" {
-		return "just now"
+		return "0 seconds"
 	}
 
 	return strings.TrimPrefix(phrase, "-")

--- a/pkg/chat/wizard_cmds.go
+++ b/pkg/chat/wizard_cmds.go
@@ -13,14 +13,15 @@ import (
 
 // Extra callback prefixes for command wizards (pics/vid/stop/delay/cams/subs/help).
 const (
-	cbPicsRoot  = "p"
-	cbVidsRoot  = "v"
-	cbCamsRoot  = "c"
-	cbStopRoot  = "t"
-	cbDelayRoot = "d"
-	cbSubsRoot  = "l"
-	cbHelpRoot  = "h"
-	cbEvtsRoot  = "e"
+	cbPicsRoot   = "p"
+	cbVidsRoot   = "v"
+	cbCamsRoot   = "c"
+	cbStopRoot   = "t"
+	cbDelayRoot  = "d"
+	cbSubsRoot   = "l"
+	cbHelpRoot   = "h"
+	cbEvtsRoot   = "e"
+	cbCamSetRoot = "k"
 )
 
 func (c *Chat) handleCommandWizardCallback(handler *Handler, data string) (*Reply, bool, bool) {
@@ -29,6 +30,10 @@ func (c *Chat) handleCommandWizardCallback(handler *Handler, data string) (*Repl
 	}
 
 	if reply, save, ok := c.handlePauseDelayWizardCallback(handler, data); ok {
+		return reply, save, true
+	}
+
+	if reply, save, ok := c.handleCamSetWizardCallback(handler, data); ok {
 		return reply, save, true
 	}
 
@@ -68,7 +73,7 @@ func (c *Chat) handleMediaWizardCallback(handler *Handler, data string) (*Reply,
 	case data == cbCamsRoot:
 		return c.camsWizardRoot(), false, true
 	case strings.HasPrefix(data, "c:") && strings.Count(data, ":") == 1:
-		return c.camsWizardCam(atoiDefault(strings.TrimPrefix(data, "c:"), -1)), false, true
+		return c.camsWizardCam(handler, atoiDefault(strings.TrimPrefix(data, "c:"), -1)), false, true
 	case strings.HasPrefix(data, "c:p:"):
 		reply, save := c.picsWizardSnap(handler, atoiDefault(strings.TrimPrefix(data, "c:p:"), -2))
 
@@ -172,7 +177,7 @@ func atoiDefault(s string, def int) int {
 }
 
 func (c *Chat) cameraButtonRows(dataPrefix string, includeAll bool) [][]Button {
-	cams := c.SSpy.Cameras.All()
+	cams := c.allCameras()
 	rows := make([][]Button, 0, len(cams)/2+3)
 
 	if includeAll {
@@ -199,7 +204,11 @@ func (c *Chat) cameraButtonRows(dataPrefix string, includeAll bool) [][]Button {
 }
 
 func (c *Chat) picsWizardRoot() *Reply {
-	_ = c.SSpy.Refresh()
+	c.refreshCameras()
+	if len(c.allCameras()) == 0 {
+		return c.noCamerasReply()
+	}
+
 	rows := c.cameraButtonRows("p:", true)
 	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
@@ -213,6 +222,10 @@ func (c *Chat) picsWizardRoot() *Reply {
 }
 
 func (c *Chat) vidsWizardRoot() *Reply {
+	if len(c.allCameras()) == 0 {
+		return c.noCamerasReply()
+	}
+
 	rows := c.cameraButtonRows("v:", true)
 	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
@@ -225,11 +238,15 @@ func (c *Chat) vidsWizardRoot() *Reply {
 }
 
 func (c *Chat) camsWizardRoot() *Reply {
-	_ = c.SSpy.Refresh()
+	c.refreshCameras()
+	cams := c.allCameras()
+	if len(cams) == 0 {
+		return c.noCamerasReply()
+	}
+
 	rows := c.cameraButtonRows("c:", false)
 	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
-	cams := c.SSpy.Cameras.All()
 	online := 0
 	for _, cam := range cams {
 		if cam.Connected.Val {
@@ -246,8 +263,8 @@ func (c *Chat) camsWizardRoot() *Reply {
 	}
 }
 
-func (c *Chat) camsWizardCam(idx int) *Reply {
-	cams := c.SSpy.Cameras.All()
+func (c *Chat) camsWizardCam(handler *Handler, idx int) *Reply {
+	cams := c.allCameras()
 	if idx < 0 || idx >= len(cams) {
 		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}
 	}
@@ -258,21 +275,27 @@ func (c *Chat) camsWizardCam(idx int) *Reply {
 		status = "down"
 	}
 
-	return &Reply{
-		Reply: fmt.Sprintf("%s (%s)\n\nSnapshot = one still photo.\nVideo = a short live clip.", cam.Name, status),
-		Edit:  true,
-		Keyboard: [][]Button{
-			{
-				{Label: "Snapshot", Data: fmt.Sprintf("c:p:%d", idx)},
-				{Label: "Video", Data: fmt.Sprintf("c:v:%d", idx)},
-			},
-			{{Label: "« Cameras", Data: cbCamsRoot}, {Label: "Done", Data: cbCancel}},
+	settings := GetCameraClipSettings(c.Subs, cam.Name)
+	msg := fmt.Sprintf("%s (%s)\n\nSnapshot = one still photo.\nVideo = a short live clip.\nClip: %s",
+		cam.Name, status, FormatClipSettings(settings))
+
+	rows := [][]Button{
+		{
+			{Label: "Snapshot", Data: fmt.Sprintf("c:p:%d", idx)},
+			{Label: "Video", Data: fmt.Sprintf("c:v:%d", idx)},
 		},
 	}
+	if handler != nil && handler.Sub != nil && handler.Sub.Admin {
+		rows = append(rows, []Button{{Label: "Clip settings", Data: fmt.Sprintf("k:%d", idx)}})
+	}
+
+	rows = append(rows, []Button{{Label: "« Cameras", Data: cbCamsRoot}, {Label: "Done", Data: cbCancel}})
+
+	return &Reply{Reply: msg, Edit: true, Keyboard: rows}
 }
 
 func (c *Chat) eventsWizardRoot() *Reply {
-	names := c.Subs.Events.Names()
+	names := CatalogEventNames(c.Subs.Events)
 	if len(names) == 0 {
 		return &Reply{
 			Reply: "No custom events are configured on this Motifini.\n\n" +
@@ -349,7 +372,7 @@ func (c *Chat) mediaWizardSnap(handler *Handler, idx int, video bool) (*Reply, b
 		}, false
 	}
 
-	cams := c.SSpy.Cameras.All()
+	cams := c.allCameras()
 	if idx < 0 || idx >= len(cams) {
 		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}, false
 	}
@@ -415,7 +438,7 @@ func (c *Chat) snapOne(handler *Handler, cam *securityspy.Camera, video bool) (s
 func (c *Chat) captureCam(handler *Handler, cam *securityspy.Camera, video bool) (string, string) {
 	if video {
 		path := filepath.Join(c.TempDir, fmt.Sprintf("chat_command_%v_%v.mp4", handler.ID, cam.Name))
-		ops := clipVidOps(cam)
+		ops, settings := c.clipVidOps(cam)
 
 		u, urlErr := cam.RedactedVideoURL(ops)
 		if urlErr == nil {
@@ -424,7 +447,7 @@ func (c *Chat) captureCam(handler *Handler, cam *securityspy.Camera, video bool)
 			c.Info.Printf("[%v] SaveVideo starting for %s", handler.ID, cam.Name)
 		}
 
-		err := cam.SaveVideo(ops, length, maxsize, path)
+		err := cam.SaveVideo(ops, settings.Length, int64(settings.Size), path)
 		if err != nil {
 			c.Error.Printf("[%v] cam.SaveVideo: capturing for %s: %v", handler.ID, cam.Name, err)
 
@@ -451,16 +474,18 @@ func (c *Chat) snapAll(handler *Handler, video bool) ([]string, string) {
 	// Sequential on purpose: SecuritySpy encodes stills slowly, and Telegram
 	// gets each file as it finishes (via handler.SendFile) so the UI doesn't freeze.
 	// Refresh first so Connected is current — skip dead cams instead of waiting on them.
-	err := c.SSpy.Refresh()
-	if err != nil {
-		c.Error.Printf("[%v] snapAll Refresh: %v", handler.ID, err)
+	if c.SSpy != nil {
+		err := c.SSpy.Refresh()
+		if err != nil {
+			c.Error.Printf("[%v] snapAll Refresh: %v", handler.ID, err)
+		}
 	}
 
 	var (
 		paths []string
 		errs  []string
 		okN   int
-		cams  = c.SSpy.Cameras.All()
+		cams  = c.allCameras()
 		total int
 	)
 
@@ -808,17 +833,21 @@ Tap a button below:`,
 func (c *Chat) helpWizardRootFor(handler *Handler) *Reply {
 	root := c.helpWizardRoot()
 	if handler != nil && handler.Sub != nil && handler.Sub.Admin {
-		// Insert Users before Done on the last row.
+		// Insert Users / Clip settings before Done on the last row.
 		rows := root.Keyboard
 		if len(rows) > 0 {
 			last := rows[len(rows)-1]
 			if len(last) > 0 && last[len(last)-1].Data == cbCancel {
-				last = append([]Button{{Label: "Users", Data: cbUsersRoot}}, last...)
+				last = append([]Button{
+					{Label: "Users", Data: cbUsersRoot},
+					{Label: "Clip set", Data: cbCamSetRoot},
+				}, last...)
 				rows[len(rows)-1] = last
 				root.Keyboard = rows
 			}
 		}
-		root.Reply += "\n• Users (admin) — allow/deny/ignore/admin/delete subscribers"
+		root.Reply += "\n• Users (admin) — allow/deny/ignore/admin/delete subscribers" +
+			"\n• Clip set (admin) — per-camera scale / length / size for everyone"
 	}
 
 	return root

--- a/pkg/chat/wizard_cmds.go
+++ b/pkg/chat/wizard_cmds.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -202,7 +201,7 @@ func (c *Chat) cameraButtonRows(dataPrefix string, includeAll bool) [][]Button {
 func (c *Chat) picsWizardRoot() *Reply {
 	_ = c.SSpy.Refresh()
 	rows := c.cameraButtonRows("p:", true)
-	rows = append(rows, []Button{{Label: "Cancel", Data: cbCancel}})
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
 	return &Reply{
 		Reply: "Grab a still photo from SecuritySpy right now.\n\n" +
@@ -215,7 +214,7 @@ func (c *Chat) picsWizardRoot() *Reply {
 
 func (c *Chat) vidsWizardRoot() *Reply {
 	rows := c.cameraButtonRows("v:", true)
-	rows = append(rows, []Button{{Label: "Cancel", Data: cbCancel}})
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
 	return &Reply{
 		Reply: "Grab a short live video clip from SecuritySpy right now.\n\n" +
@@ -228,7 +227,7 @@ func (c *Chat) vidsWizardRoot() *Reply {
 func (c *Chat) camsWizardRoot() *Reply {
 	_ = c.SSpy.Refresh()
 	rows := c.cameraButtonRows("c:", false)
-	rows = append(rows, []Button{{Label: "Cancel", Data: cbCancel}})
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
 	cams := c.SSpy.Cameras.All()
 	online := 0
@@ -267,7 +266,7 @@ func (c *Chat) camsWizardCam(idx int) *Reply {
 				{Label: "Snapshot", Data: fmt.Sprintf("c:p:%d", idx)},
 				{Label: "Video", Data: fmt.Sprintf("c:v:%d", idx)},
 			},
-			{{Label: "« Cameras", Data: cbCamsRoot}, {Label: "Cancel", Data: cbCancel}},
+			{{Label: "« Cameras", Data: cbCamsRoot}, {Label: "Done", Data: cbCancel}},
 		},
 	}
 }
@@ -281,7 +280,7 @@ func (c *Chat) eventsWizardRoot() *Reply {
 			Edit: true,
 			Keyboard: [][]Button{
 				{{Label: "Subscribe to camera", Data: cbSubCam}},
-				{{Label: "Cancel", Data: cbCancel}},
+				{{Label: "Done", Data: cbCancel}},
 			},
 		}
 	}
@@ -301,7 +300,7 @@ func (c *Chat) eventsWizardRoot() *Reply {
 			Data:  fmt.Sprintf("e:s:%d", idx),
 		}})
 	}
-	rows = append(rows, []Button{{Label: "Cancel", Data: cbCancel}})
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
 	return &Reply{
 		Reply: "System and custom events (not camera motion clips).\n\n" +
@@ -404,7 +403,7 @@ func (c *Chat) snapOne(handler *Handler, cam *securityspy.Camera, video bool) (s
 
 	err := handler.SendFile(path, caption)
 	if err != nil {
-		log.Printf("[ERROR] [%v] SendFile %s: %v", handler.ID, cam.Name, err)
+		c.Error.Printf("[%v] SendFile %s: %v", handler.ID, cam.Name, err)
 		_ = os.Remove(path)
 
 		return "", "Error Sending '" + cam.Name + "': " + err.Error()
@@ -416,11 +415,18 @@ func (c *Chat) snapOne(handler *Handler, cam *securityspy.Camera, video bool) (s
 func (c *Chat) captureCam(handler *Handler, cam *securityspy.Camera, video bool) (string, string) {
 	if video {
 		path := filepath.Join(c.TempDir, fmt.Sprintf("chat_command_%v_%v.mp4", handler.ID, cam.Name))
-		log.Printf("[INFO] [%v] SaveVideo starting for %s", handler.ID, cam.Name)
+		ops := clipVidOps(cam)
 
-		err := cam.SaveVideo(clipVidOps(cam), length, maxsize, path)
+		u, urlErr := cam.RedactedVideoURL(ops)
+		if urlErr == nil {
+			c.Debug.Printf("[%v] SaveVideo %s URL: %s", handler.ID, cam.Name, u)
+		} else {
+			c.Info.Printf("[%v] SaveVideo starting for %s", handler.ID, cam.Name)
+		}
+
+		err := cam.SaveVideo(ops, length, maxsize, path)
 		if err != nil {
-			log.Printf("[ERROR] [%v] cam.SaveVideo: capturing for %s: %v", handler.ID, cam.Name, err)
+			c.Error.Printf("[%v] cam.SaveVideo: capturing for %s: %v", handler.ID, cam.Name, err)
 
 			return "", "Error Getting '" + cam.Name + "' Video: " + err.Error()
 		}
@@ -429,11 +435,11 @@ func (c *Chat) captureCam(handler *Handler, cam *securityspy.Camera, video bool)
 	}
 
 	path := filepath.Join(c.TempDir, fmt.Sprintf("chat_command_%v_%v.jpg", handler.ID, cam.Name))
-	log.Printf("[INFO] [%v] SaveJPEG starting for %s", handler.ID, cam.Name)
+	c.Info.Printf("[%v] SaveJPEG starting for %s", handler.ID, cam.Name)
 
 	err := cam.SaveJPEG(&securityspy.VidOps{Height: jpegHeight, Quality: quality}, path)
 	if err != nil {
-		log.Printf("[ERROR] [%v] cam.SaveJPEG: capturing for %s: %v", handler.ID, cam.Name, err)
+		c.Error.Printf("[%v] cam.SaveJPEG: capturing for %s: %v", handler.ID, cam.Name, err)
 
 		return "", "Error Getting '" + cam.Name + "' Picture: " + err.Error()
 	}
@@ -447,7 +453,7 @@ func (c *Chat) snapAll(handler *Handler, video bool) ([]string, string) {
 	// Refresh first so Connected is current — skip dead cams instead of waiting on them.
 	err := c.SSpy.Refresh()
 	if err != nil {
-		log.Printf("[ERROR] [%v] snapAll Refresh: %v", handler.ID, err)
+		c.Error.Printf("[%v] snapAll Refresh: %v", handler.ID, err)
 	}
 
 	var (
@@ -467,7 +473,7 @@ func (c *Chat) snapAll(handler *Handler, video bool) ([]string, string) {
 		total++
 	}
 
-	log.Printf("[INFO] [%v] snapAll starting (%d online cameras, video=%v)", handler.ID, total, video)
+	c.Info.Printf("[%v] snapAll starting (%d online cameras, video=%v)", handler.ID, total, video)
 
 	for _, cam := range cams {
 		if !cam.Connected.Val {
@@ -512,7 +518,7 @@ func (c *Chat) stopWizardRoot() *Reply {
 				{Label: "1 hour", Data: "t:60"},
 				{Label: "Clear pause", Data: "t:0"},
 			},
-			{{Label: "Cancel", Data: cbCancel}},
+			{{Label: "Done", Data: cbCancel}},
 		},
 	}
 }
@@ -532,7 +538,7 @@ func (c *Chat) stopWizardTargets(handler *Handler, minsStr string) *Reply {
 
 	rows = append(rows, []Button{
 		{Label: "« Back", Data: cbStopRoot},
-		{Label: "Cancel", Data: cbCancel},
+		{Label: "Done", Data: cbCancel},
 	})
 
 	var action string
@@ -620,17 +626,17 @@ func (c *Chat) delayWizardRoot(handler *Handler) *Reply {
 			Edit: true,
 			Keyboard: [][]Button{
 				{{Label: "Subscribe", Data: cbSubRoot}},
-				{{Label: "Cancel", Data: cbCancel}},
+				{{Label: "Done", Data: cbCancel}},
 			},
 		}
 	}
 
 	rows := make([][]Button, 0, len(names)+1)
 	for i, name := range names {
-		label := fmt.Sprintf("%s (%s)", formatSubLabel(name), eventDelay(handler.Sub.Events, name))
+		label := fmt.Sprintf("%s (%s)", formatSubLabel(name), formatDuration(eventDelay(handler.Sub.Events, name)))
 		rows = append(rows, []Button{{Label: label, Data: fmt.Sprintf("d:%d", i)}})
 	}
-	rows = append(rows, []Button{{Label: "Cancel", Data: cbCancel}})
+	rows = append(rows, []Button{{Label: "Done", Data: cbCancel}})
 
 	return &Reply{
 		Reply: "How often should Motifini text you about the same camera?\n\n" +
@@ -654,15 +660,21 @@ func (c *Chat) delayWizardSeconds(idxStr string) *Reply {
 		Edit: true,
 		Keyboard: [][]Button{
 			{
-				{Label: "30s", Data: fmt.Sprintf("d:%d:30", idx)},
-				{Label: "60s", Data: fmt.Sprintf("d:%d:60", idx)},
-				{Label: "2 min", Data: fmt.Sprintf("d:%d:120", idx)},
+				{Label: "10s", Data: fmt.Sprintf("d:%d:10", idx)},
+				{Label: "15s", Data: fmt.Sprintf("d:%d:15", idx)},
+				{Label: "20s", Data: fmt.Sprintf("d:%d:20", idx)},
 			},
 			{
+				{Label: "30s", Data: fmt.Sprintf("d:%d:30", idx)},
+				{Label: "60s", Data: fmt.Sprintf("d:%d:60", idx)},
+				{Label: "90s", Data: fmt.Sprintf("d:%d:90", idx)},
+			},
+			{
+				{Label: "2 min", Data: fmt.Sprintf("d:%d:120", idx)},
 				{Label: "5 min", Data: fmt.Sprintf("d:%d:300", idx)},
 				{Label: "10 min", Data: fmt.Sprintf("d:%d:600", idx)},
 			},
-			{{Label: "« Back", Data: cbDelayRoot}, {Label: "Cancel", Data: cbCancel}},
+			{{Label: "« Back", Data: cbDelayRoot}, {Label: "Done", Data: cbCancel}},
 		},
 	}
 }
@@ -686,9 +698,9 @@ func (c *Chat) delayWizardApply(handler *Handler, payload string) (*Reply, bool)
 
 	return &Reply{
 		Reply: fmt.Sprintf(
-			"Got it. After Motifini sends a clip for '%s', it will wait at least %ds "+
+			"Got it. After Motifini sends a clip for '%s', it will wait at least %s "+
 				"before sending another for that same subscription.",
-			formatSubLabel(event), secs),
+			formatSubLabel(event), formatDuration(time.Duration(secs)*time.Second)),
 		Edit:  true,
 		Toast: "Saved",
 		Keyboard: [][]Button{
@@ -711,11 +723,11 @@ func (c *Chat) subsWizardRoot(handler *Handler) *Reply {
 	rows := make([][]Button, 0, len(names)+2)
 	for idx, event := range names {
 		line := formatSubLabel(event)
-		fmt.Fprintf(&msg, "\n• %s · every %v", line, eventDelay(handler.Sub.Events, event))
+		fmt.Fprintf(&msg, "\n• %s · every %s", line, formatDuration(eventDelay(handler.Sub.Events, event)))
 
 		if handler.Sub.Events.IsPaused(event) {
-			until := time.Until(handler.Sub.Events.PauseTime(event)).Round(time.Second)
-			fmt.Fprintf(&msg, " (paused %v)", until)
+			until := time.Until(handler.Sub.Events.PauseTime(event))
+			fmt.Fprintf(&msg, " (paused %s)", formatDuration(until))
 		}
 
 		rows = append(rows, []Button{{Label: line, Data: fmt.Sprintf("l:%d", idx)}})

--- a/pkg/chat/wizard_cmds.go
+++ b/pkg/chat/wizard_cmds.go
@@ -276,8 +276,13 @@ func (c *Chat) camsWizardCam(handler *Handler, idx int) *Reply {
 	}
 
 	settings := GetCameraClipSettings(c.Subs, cam.Name)
+	clip := FormatClipSettings(settings)
+	if frame := cameraFrameSize(cam); frame != "" {
+		clip += " (" + frame + ")"
+	}
+
 	msg := fmt.Sprintf("%s (%s)\n\nSnapshot = one still photo.\nVideo = a short live clip.\nClip: %s",
-		cam.Name, status, FormatClipSettings(settings))
+		cam.Name, status, clip)
 
 	rows := [][]Button{
 		{

--- a/pkg/messenger/telegram.go
+++ b/pkg/messenger/telegram.go
@@ -411,7 +411,11 @@ func (m *Messenger) SendTelegramFile(reqID, path, caption string, telegramID int
 		video := tgbotapi.NewVideo(telegramID, tgbotapi.FilePath(path))
 		video.SupportsStreaming = true
 		video.Caption = caption
+		started := time.Now()
 		_, err = m.telebot.Send(video)
+		if err == nil {
+			m.Info.Printf("[%s] Telegram: Sent Video to %s in %s", reqID, dest, time.Since(started).Round(time.Millisecond))
+		}
 	case ".wav", ".mp3":
 		m.Info.Printf("[%s] Telegram: Sending Audio (%s, %.2fMb) to %s",
 			reqID, path, float64(fileInfo.Size())/mebibyte, dest)

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -17,7 +17,6 @@ const (
 	eventRetry     = 5 * time.Second
 	defaultLength  = 6 * time.Second
 	defaultSize    = 1.5 * 1024 * 1024
-	defaultCodec   = "aac"
 	defaultHeight  = 720
 )
 
@@ -48,15 +47,19 @@ func (m *Motifini) dispatchEvent(event *securityspy.Event) {
 		// ignore.
 	case securityspy.EventMotionDetected:
 		// v4 motion event.
-		if strings.HasPrefix(m.SSpy.Info.Version, "4") {
+		if m.SSpy.Info != nil && strings.HasPrefix(m.SSpy.Info.Version, "4") {
 			m.handleCameraMotion(event)
 		}
 	case securityspy.EventTriggerAction:
 		// v5 action event. (motion detected, actions enabled)
 		m.handleCameraMotion(event)
 	case securityspy.EventStreamConnect:
+		m.streamLive = true
 		m.Info.Println("SecuritySpy Event Stream Connected!")
-		m.notifySystemEvent(chat.EventStreamUp, "SecuritySpy event stream is back up.")
+
+		if m.streamSawDown {
+			m.notifySystemEvent(chat.EventStreamUp, "SecuritySpy event stream is back up.")
+		}
 	case securityspy.EventStreamDisconnect:
 		m.handleStreamDisconnect(event)
 	case securityspy.EventOffline:
@@ -91,6 +94,14 @@ func (m *Motifini) logStreamEvent(event *securityspy.Event) {
 }
 
 func (m *Motifini) handleStreamDisconnect(event *securityspy.Event) {
+	if !m.streamLive {
+		// Failed dials before any successful connect are not real disconnects.
+		m.Debug.Printf("SecuritySpy event stream not connected yet: %v", event.Msg)
+		return
+	}
+
+	m.streamLive = false
+	m.streamSawDown = true
 	m.Error.Println("SecuritySpy Event Stream Disconnected")
 
 	msg := "SecuritySpy event stream went down."
@@ -154,12 +165,14 @@ func (m *Motifini) handleCameraMotion(event *securityspy.Event) {
 		return // no one to notify of this camera's motion
 	}
 
-	err := event.Camera.SaveVideo(
-		&securityspy.VidOps{
-			ACodec: defaultCodec,
-			Height: defaultHeight,
-			VCodec: event.Camera.PreferredVCodec(),
-		}, defaultLength, defaultSize, path)
+	ops := chat.VideoClipOps(event.Camera, defaultHeight)
+
+	u, urlErr := event.Camera.RedactedVideoURL(ops)
+	if urlErr == nil {
+		m.Debug.Printf("[%v] SaveVideo %s URL: %s", reqID, event.Camera.Name, u)
+	}
+
+	err := event.Camera.SaveVideo(ops, defaultLength, defaultSize, path)
 	if err != nil {
 		m.Error.Printf("[%v] event.Camera.SaveVideo: %v", reqID, err)
 		return

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -15,9 +15,6 @@ import (
 const (
 	eventStreamBuf = 1000
 	eventRetry     = 5 * time.Second
-	defaultLength  = 6 * time.Second
-	defaultSize    = 1.5 * 1024 * 1024
-	defaultHeight  = 720
 )
 
 // ProcessEventStream processes the securityspy event stream.
@@ -165,14 +162,15 @@ func (m *Motifini) handleCameraMotion(event *securityspy.Event) {
 		return // no one to notify of this camera's motion
 	}
 
-	ops := chat.VideoClipOps(event.Camera, defaultHeight)
+	settings := chat.GetCameraClipSettings(m.Subs, event.Camera.Name)
+	ops := chat.VideoClipOps(event.Camera, settings)
 
 	u, urlErr := event.Camera.RedactedVideoURL(ops)
 	if urlErr == nil {
 		m.Debug.Printf("[%v] SaveVideo %s URL: %s", reqID, event.Camera.Name, u)
 	}
 
-	err := event.Camera.SaveVideo(ops, defaultLength, defaultSize, path)
+	err := event.Camera.SaveVideo(ops, settings.Length, int64(settings.Size), path)
 	if err != nil {
 		m.Error.Printf("[%v] event.Camera.SaveVideo: %v", reqID, err)
 		return

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -43,8 +43,13 @@ func (m *Motifini) dispatchEvent(event *securityspy.Event) {
 	case securityspy.EventKeepAlive, securityspy.EventTriggerMotion:
 		// ignore.
 	case securityspy.EventMotionDetected:
-		// v4 motion event.
-		if m.SSpy.Info != nil && strings.HasPrefix(m.SSpy.Info.Version, "4") {
+		// v4 motion. If Info is not loaded yet (Refresh still retrying), treat as motion
+		// rather than dropping early events after the stream connects.
+		if m.SSpy == nil {
+			break
+		}
+
+		if m.SSpy.Info == nil || strings.HasPrefix(m.SSpy.Info.Version, "4") {
 			m.handleCameraMotion(event)
 		}
 	case securityspy.EventTriggerAction:

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -121,11 +121,13 @@ func (m *Motifini) handleConfigChange() {
 	m.saveSubDB() // just because.
 	m.Info.Println("SecuritySpy Configuration Changed! Stopping webserver and messenger to refresh SecuritySpy data.")
 
-	err := m.HTTP.Stop()
-	if err != nil {
-		m.Error.Println("Stopping Webserver:", err)
+	if m.HTTP != nil {
+		err := m.HTTP.Stop()
+		if err != nil {
+			m.Error.Println("Stopping Webserver:", err)
+		}
+		defer m.HTTP.Start()
 	}
-	defer m.HTTP.Start()
 
 	if m.Msgs != nil {
 		m.Msgs.Stop()
@@ -138,9 +140,11 @@ func (m *Motifini) handleConfigChange() {
 		}()
 	}
 
-	err = m.SSpy.Refresh()
-	if err != nil {
-		m.Error.Println("Refreshing SecuritySpy Configuration:", err)
+	if m.SSpy != nil {
+		err := m.SSpy.Refresh()
+		if err != nil {
+			m.Error.Println("Refreshing SecuritySpy Configuration:", err)
+		}
 	}
 
 	time.Sleep(time.Second)

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -148,7 +148,7 @@ func (m *Motifini) handleConfigChange() {
 	if m.SSpy != nil {
 		err := m.SSpy.Refresh()
 		if err != nil {
-			m.Error.Println("Refreshing SecuritySpy Configuration:", err)
+			m.Debug.Println("Refreshing SecuritySpy Configuration:", err)
 		}
 	}
 

--- a/pkg/motifini/eventstream.go
+++ b/pkg/motifini/eventstream.go
@@ -162,6 +162,10 @@ func (m *Motifini) handleCameraMotion(event *securityspy.Event) {
 		return // no one to notify of this camera's motion
 	}
 
+	if m.Msgs == nil {
+		return
+	}
+
 	settings := chat.GetCameraClipSettings(m.Subs, event.Camera.Name)
 	ops := chat.VideoClipOps(event.Camera, settings)
 
@@ -204,6 +208,10 @@ func (m *Motifini) handleCameraMotion(event *securityspy.Event) {
 
 // notifySystemEvent texts subscribers of a built-in non-camera event (no video attachment).
 func (m *Motifini) notifySystemEvent(eventName, msg string) {
+	if m.Msgs == nil {
+		return // messenger not up yet (event stream can connect during startup)
+	}
+
 	subs := m.Subs.GetSubscribers(eventName)
 	if len(subs) < 1 {
 		return

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -300,6 +300,9 @@ func (m *Motifini) Run() error {
 		}
 	}
 
+	m.notifySystemEvent(chat.EventStarted,
+		fmt.Sprintf("Motifini %s-%s started (PID %d).", version.Version, version.Revision, os.Getpid()))
+
 	return m.waitForSignal()
 }
 

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -300,8 +300,11 @@ func (m *Motifini) Run() error {
 		}
 	}
 
-	m.notifySystemEvent(chat.EventStarted,
-		fmt.Sprintf("Motifini %s-%s started (PID %d).", version.Version, version.Revision, os.Getpid()))
+	m.notifySystemEvent(chat.EventStarted, fmt.Sprintf(
+		"Motifini %s-%s started at %s (PID %d).",
+		version.Version, version.Revision,
+		time.Now().Local().Format("2006-01-02 15:04:05 MST"),
+		os.Getpid()))
 
 	return m.waitForSignal()
 }

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/davidnewhall/motifini/pkg/chat"
 	"github.com/davidnewhall/motifini/pkg/export"
@@ -30,9 +31,10 @@ const (
 	Binary           = "motifini"
 	DefaultEnvPrefix = "MO"
 
-	defaultLogFileMb = 5
-	defaultLogFiles  = 10
-	megabyte         = 1024 * 1024
+	defaultLogFileMb        = 5
+	defaultLogFiles         = 10
+	defaultSecuritySpyRetry = 5 * time.Second
+	megabyte                = 1024 * 1024
 )
 
 // DefaultRepeatDelay mirrors chat.DefaultRepeatDelay for callers outside pkg/chat.
@@ -40,19 +42,21 @@ const DefaultRepeatDelay = chat.DefaultRepeatDelay
 
 // Motifini is the main application struct.
 type Motifini struct {
-	Flag      *Flags
-	Conf      *Config
-	HTTP      *webserver.Config
-	SSpy      *securityspy.Server
-	Subs      *subscribe.Subscribe
-	Msgs      *messenger.Messenger
-	Info      *log.Logger
-	Error     *log.Logger
-	Debug     *log.Logger
-	Event     *log.Logger // SecuritySpy event stream (optional rotating file)
-	logWriter io.Writer   // Info/MSGS/HTTP sink (stdout and/or rotating log_file)
-	appLog    io.Closer
-	eventLog  io.Closer
+	Flag          *Flags
+	Conf          *Config
+	HTTP          *webserver.Config
+	SSpy          *securityspy.Server
+	Subs          *subscribe.Subscribe
+	Msgs          *messenger.Messenger
+	Info          *log.Logger
+	Error         *log.Logger
+	Debug         *log.Logger
+	Event         *log.Logger // SecuritySpy event stream (optional rotating file)
+	logWriter     io.Writer   // Info/MSGS/HTTP sink (stdout and/or rotating log_file)
+	appLog        io.Closer
+	eventLog      io.Closer
+	streamLive    bool // true between EventStreamConnect and Disconnect
+	streamSawDown bool // true after a real disconnect (so "back up" is meaningful)
 }
 
 // Flags defines our application's CLI arguments.
@@ -67,13 +71,14 @@ type Flags struct {
 // Config is the configuration for Motifini.
 type Config struct {
 	Global struct {
-		TempDir   string `toml:"temp_dir"`
-		StateFile string `toml:"state_file"`
-		LogFile   string `toml:"log_file"`    // optional rotating app log (info/error/debug)
-		EventLog  string `toml:"event_log"`   // optional rotating SecuritySpy event stream log
-		LogFiles  int    `toml:"log_files"`   // rotated log file count (default 10)
-		LogFileMb int    `toml:"log_file_mb"` // rotated log size in MB (default 5)
-		Debug     bool   `toml:"debug"`
+		TempDir          string        `toml:"temp_dir"`
+		StateFile        string        `toml:"state_file"`
+		LogFile          string        `toml:"log_file"`           // optional rotating app log (info/error/debug)
+		EventLog         string        `toml:"event_log"`          // optional rotating SecuritySpy event stream log
+		LogFiles         int           `toml:"log_files"`          // rotated log file count (default 10)
+		LogFileMb        int           `toml:"log_file_mb"`        // rotated log size in MB (default 5)
+		SecuritySpyRetry cnfg.Duration `toml:"security_spy_retry"` // reconnect interval when SS is down (default 5s)
+		Debug            bool          `toml:"debug"`
 	} `toml:"motifini"`
 	Webserver struct {
 		Port      uint     `toml:"port"`
@@ -257,6 +262,10 @@ func (c *Config) Validate() {
 	if c.Global.LogFiles < 1 {
 		c.Global.LogFiles = defaultLogFiles
 	}
+
+	if c.Global.SecuritySpyRetry.Duration <= 0 {
+		c.Global.SecuritySpyRetry.Duration = defaultSecuritySpyRetry
+	}
 }
 
 // Run starts the app after all configs are collected.
@@ -272,12 +281,7 @@ func (m *Motifini) Run() error {
 
 	chat.EnsureBuiltInEvents(m.Subs)
 
-	m.Info.Println("Connecting to SecuritySpy:", m.Conf.SecuritySpy.URL)
-
-	m.SSpy, err = securityspy.New(m.Conf.SecuritySpy)
-	if err != nil {
-		return fmt.Errorf("connecting to securityspy: %w", err)
-	}
+	m.connectSecuritySpy()
 
 	m.publishDebugStats()
 	m.ProcessEventStream()
@@ -298,10 +302,51 @@ func (m *Motifini) Run() error {
 	return m.waitForSignal()
 }
 
+// connectSecuritySpy builds the client and refreshes once. Startup continues even when
+// SecuritySpy is down; a background loop retries until Refresh succeeds.
+func (m *Motifini) connectSecuritySpy() {
+	m.Info.Println("Connecting to SecuritySpy:", m.Conf.SecuritySpy.URL)
+
+	m.SSpy = securityspy.NewMust(m.Conf.SecuritySpy)
+
+	err := m.SSpy.Refresh()
+	if err == nil {
+		m.Info.Printf("Connected to SecuritySpy (%d cameras)", len(m.SSpy.Cameras.All()))
+		return
+	}
+
+	retry := m.Conf.Global.SecuritySpyRetry.Duration
+	m.Error.Printf("SecuritySpy unavailable: %v — will retry every %s", err, retry)
+	go m.retrySecuritySpy(retry)
+}
+
+func (m *Motifini) retrySecuritySpy(interval time.Duration) {
+	for {
+		time.Sleep(interval)
+
+		err := m.SSpy.Refresh()
+		if err != nil {
+			m.Debug.Printf("SecuritySpy still unavailable: %v — retrying in %s", err, interval)
+			continue
+		}
+
+		m.Info.Printf("Connected to SecuritySpy (%d cameras)", len(m.SSpy.Cameras.All()))
+
+		return
+	}
+}
+
 // startMessenger builds and connects the chat/messenger stack.
 func (m *Motifini) startMessenger() error {
 	m.Msgs = &messenger.Messenger{
-		Chat:     chat.New(&chat.Chat{TempDir: m.Conf.Global.TempDir, Subs: m.Subs, SSpy: m.SSpy}),
+		Chat: chat.New(&chat.Chat{
+			TempDir: m.Conf.Global.TempDir,
+			Subs:    m.Subs,
+			SSpy:    m.SSpy,
+			Info:    log.New(m.logWriter, "[CHAT] ", m.Info.Flags()),
+			Debug:   m.Debug,
+			Error:   m.Error,
+		}),
 		Subs:     m.Subs,
 		Telegram: m.Conf.Telegram,
 		TempDir:  m.Conf.Global.TempDir,
@@ -357,14 +402,14 @@ func (m *Motifini) publishDebugStats() {
 		return int64(len(m.Subs.GetAdmins()))
 	})
 	export.PublishCount("cameras", func() int64 {
-		if m.SSpy == nil {
+		if m.SSpy == nil || m.SSpy.Cameras == nil {
 			return 0
 		}
 
 		return int64(len(m.SSpy.Cameras.All()))
 	})
 	export.PublishCount("cameras_online", func() int64 {
-		if m.SSpy == nil {
+		if m.SSpy == nil || m.SSpy.Cameras == nil {
 			return 0
 		}
 

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -281,11 +281,12 @@ func (m *Motifini) Run() error {
 
 	chat.EnsureBuiltInEvents(m.Subs)
 
-	m.connectSecuritySpy()
+	if m.connectSecuritySpy() {
+		m.ProcessEventStream()
+		defer m.SSpy.Events.Stop(true)
+	}
 
 	m.publishDebugStats()
-	m.ProcessEventStream()
-	defer m.SSpy.Events.Stop(true)
 
 	err = m.startMessenger()
 	if err != nil {
@@ -305,12 +306,13 @@ func (m *Motifini) Run() error {
 // connectSecuritySpy builds the client and refreshes once. Startup continues even when
 // SecuritySpy is down; a background loop retries until Refresh succeeds.
 // NewMust only builds the client (no network); connectivity failures come from Refresh.
-func (m *Motifini) connectSecuritySpy() {
-	if m.Conf.SecuritySpy == nil {
+// Returns false when [security_spy] is missing so the event stream is not started.
+func (m *Motifini) connectSecuritySpy() bool {
+	if m.Conf.SecuritySpy == nil || m.Conf.SecuritySpy.URL == "" {
 		m.Error.Println("SecuritySpy config missing — camera features disabled")
 		m.SSpy = securityspy.NewMust(&server.Config{URL: "http://127.0.0.1/"})
 
-		return
+		return false
 	}
 
 	m.Info.Println("Connecting to SecuritySpy:", m.Conf.SecuritySpy.URL)
@@ -320,12 +322,14 @@ func (m *Motifini) connectSecuritySpy() {
 	err := m.SSpy.Refresh()
 	if err == nil {
 		m.Info.Printf("Connected to SecuritySpy (%d cameras)", len(m.SSpy.Cameras.All()))
-		return
+		return true
 	}
 
 	retry := m.Conf.Global.SecuritySpyRetry.Duration
 	m.Error.Printf("SecuritySpy unavailable: %v — will retry every %s", err, retry)
 	go m.retrySecuritySpy(retry)
+
+	return true
 }
 
 func (m *Motifini) retrySecuritySpy(interval time.Duration) {

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -303,7 +303,7 @@ func (m *Motifini) Run() error {
 	m.notifySystemEvent(chat.EventStarted, fmt.Sprintf(
 		"Motifini %s-%s started at %s (PID %d).",
 		version.Version, version.Revision,
-		time.Now().Local().Format("2006-01-02 15:04:05 MST"),
+		time.Now().Format("2006-01-02 15:04:05 MST"),
 		os.Getpid()))
 
 	return m.waitForSignal()

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -310,7 +310,7 @@ func (m *Motifini) Run() error {
 func (m *Motifini) connectSecuritySpy() bool {
 	if m.Conf.SecuritySpy == nil || m.Conf.SecuritySpy.URL == "" {
 		m.Error.Println("SecuritySpy config missing — camera features disabled")
-		m.SSpy = securityspy.NewMust(&server.Config{URL: "http://127.0.0.1/"})
+		m.SSpy = nil
 
 		return false
 	}

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -304,7 +304,15 @@ func (m *Motifini) Run() error {
 
 // connectSecuritySpy builds the client and refreshes once. Startup continues even when
 // SecuritySpy is down; a background loop retries until Refresh succeeds.
+// NewMust only builds the client (no network); connectivity failures come from Refresh.
 func (m *Motifini) connectSecuritySpy() {
+	if m.Conf.SecuritySpy == nil {
+		m.Error.Println("SecuritySpy config missing — camera features disabled")
+		m.SSpy = securityspy.NewMust(&server.Config{URL: "http://127.0.0.1/"})
+
+		return
+	}
+
 	m.Info.Println("Connecting to SecuritySpy:", m.Conf.SecuritySpy.URL)
 
 	m.SSpy = securityspy.NewMust(m.Conf.SecuritySpy)

--- a/pkg/webserver/webhandler_events.go
+++ b/pkg/webserver/webhandler_events.go
@@ -38,7 +38,7 @@ func (c *Config) notifyHandler(
 	reqID string, vars map[string]string, writer http.ResponseWriter, request *http.Request,
 ) {
 	code, reply := http.StatusOK, "REQ ID: "+reqID+", msg: got notify\n"
-	cam := c.SSpy.Cameras.ByName(vars["event"])
+	cam := c.cameraByName(vars["event"])
 	subs := c.Subs.GetSubscribers(vars["event"])
 	path := ""
 

--- a/pkg/webserver/webhandler_events.go
+++ b/pkg/webserver/webhandler_events.go
@@ -50,6 +50,7 @@ func (c *Config) notifyHandler(
 		if err != nil {
 			c.Error.Printf("[%v] cam.SaveJPEG: %v", reqID, err)
 			code, reply = http.StatusInternalServerError, "ERROR: "+err.Error()
+			path = "" // fall back to text-only; do not attach a missing/partial file
 		}
 	}
 

--- a/pkg/webserver/webhandler_events.go
+++ b/pkg/webserver/webhandler_events.go
@@ -38,13 +38,6 @@ func (c *Config) notifyHandler(
 	reqID string, vars map[string]string, writer http.ResponseWriter, request *http.Request,
 ) {
 	msg := request.FormValue("msg")
-	if !c.securitySpyReady() && msg == "" {
-		c.finishReq(writer, request, reqID, http.StatusServiceUnavailable,
-			"ERROR: SecuritySpy not ready (cameras not loaded)\n", vars["event"])
-
-		return
-	}
-
 	code, reply := http.StatusOK, "REQ ID: "+reqID+", msg: got notify\n"
 	cam := c.cameraByName(vars["event"])
 	subs := c.Subs.GetSubscribers(vars["event"])

--- a/pkg/webserver/webhandler_events.go
+++ b/pkg/webserver/webhandler_events.go
@@ -37,6 +37,14 @@ func (c *Config) eventsHandler(writer http.ResponseWriter, request *http.Request
 func (c *Config) notifyHandler(
 	reqID string, vars map[string]string, writer http.ResponseWriter, request *http.Request,
 ) {
+	msg := request.FormValue("msg")
+	if !c.securitySpyReady() && msg == "" {
+		c.finishReq(writer, request, reqID, http.StatusServiceUnavailable,
+			"ERROR: SecuritySpy not connected yet\n", vars["event"])
+
+		return
+	}
+
 	code, reply := http.StatusOK, "REQ ID: "+reqID+", msg: got notify\n"
 	cam := c.cameraByName(vars["event"])
 	subs := c.Subs.GetSubscribers(vars["event"])
@@ -52,10 +60,14 @@ func (c *Config) notifyHandler(
 		}
 	}
 
-	msg := request.FormValue("msg")
-	if msg == "" && cam != nil {
-		msg = cam.Name
+	if msg == "" {
+		if cam != nil {
+			msg = cam.Name
+		} else {
+			msg = vars["event"]
+		}
 	}
+
 	c.Msgs.SendFileOrMsg(reqID, msg, path, subs)
 	c.finishReq(writer, request, reqID, code, reply, msg)
 }

--- a/pkg/webserver/webhandler_events.go
+++ b/pkg/webserver/webhandler_events.go
@@ -40,7 +40,7 @@ func (c *Config) notifyHandler(
 	msg := request.FormValue("msg")
 	if !c.securitySpyReady() && msg == "" {
 		c.finishReq(writer, request, reqID, http.StatusServiceUnavailable,
-			"ERROR: SecuritySpy not connected yet\n", vars["event"])
+			"ERROR: SecuritySpy not ready (cameras not loaded)\n", vars["event"])
 
 		return
 	}

--- a/pkg/webserver/webhandler_send.go
+++ b/pkg/webserver/webhandler_send.go
@@ -151,12 +151,12 @@ func (c *Config) sendPictureHandler(writer http.ResponseWriter, request *http.Re
 	cam := c.cameraByName(name)
 
 	switch {
-	case !c.securitySpyReady():
-		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
-		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 	case name == "" || code == http.StatusInternalServerError:
 		code, reply = http.StatusInternalServerError, "ERROR: Missing 'to' or 'cam', name: "+name
 		c.Debug.Printf("[%v] Invalid 'to' provided or 'cam' empty: %v", reqID, name)
+	case !c.securitySpyReady():
+		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
+		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 	case cam == nil:
 		code, reply = http.StatusInternalServerError, "ERROR: Camera not found: "+name
 		c.Debug.Printf("[%v] Camera not found: %v", reqID, name)

--- a/pkg/webserver/webhandler_send.go
+++ b/pkg/webserver/webhandler_send.go
@@ -31,13 +31,15 @@ func (c *Config) sendVideoHandler(writer http.ResponseWriter, request *http.Requ
 	}
 	reqID, code, reply := messenger.ReqID(messenger.IDLength), http.StatusOK, "OK"
 
-	if name == "" {
+	cam := c.cameraByName(name)
+	switch {
+	case name == "":
 		c.Debug.Printf("[%v] Missing 'cam' provided", reqID)
 		code, reply = http.StatusInternalServerError, "ERROR: Missing 'to' or 'cam'"
-	} else if !c.securitySpyReady() {
+	case !c.securitySpyReady():
 		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
-	} else if cam == nil {
+	case cam == nil:
 		c.Debug.Printf("[%v] Invalid 'cam' provided: %v", reqID, name)
 		code, reply = http.StatusInternalServerError, "ERROR: Camera not found in configuration!"
 	}

--- a/pkg/webserver/webhandler_send.go
+++ b/pkg/webserver/webhandler_send.go
@@ -31,8 +31,10 @@ func (c *Config) sendVideoHandler(writer http.ResponseWriter, request *http.Requ
 	}
 	reqID, code, reply := messenger.ReqID(messenger.IDLength), http.StatusOK, "OK"
 
-	cam := c.cameraByName(name)
-	if !c.securitySpyReady() {
+	if name == "" {
+		c.Debug.Printf("[%v] Missing 'cam' provided", reqID)
+		code, reply = http.StatusInternalServerError, "ERROR: Missing 'to' or 'cam'"
+	} else if !c.securitySpyReady() {
 		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
 	} else if cam == nil {

--- a/pkg/webserver/webhandler_send.go
+++ b/pkg/webserver/webhandler_send.go
@@ -31,8 +31,11 @@ func (c *Config) sendVideoHandler(writer http.ResponseWriter, request *http.Requ
 	}
 	reqID, code, reply := messenger.ReqID(messenger.IDLength), http.StatusOK, "OK"
 
-	cam := c.SSpy.Cameras.ByName(name)
-	if cam == nil {
+	cam := c.cameraByName(name)
+	if !c.securitySpyReady() {
+		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
+		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not connected yet"
+	} else if cam == nil {
 		c.Debug.Printf("[%v] Invalid 'cam' provided: %v", reqID, name)
 		code, reply = http.StatusInternalServerError, "ERROR: Camera not found in configuration!"
 	}
@@ -145,9 +148,12 @@ func (c *Config) sendPictureHandler(writer http.ResponseWriter, request *http.Re
 		}
 	}
 
-	cam := c.SSpy.Cameras.ByName(name)
+	cam := c.cameraByName(name)
 
 	switch {
+	case !c.securitySpyReady():
+		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not connected yet"
+		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 	case name == "" || code == http.StatusInternalServerError:
 		code, reply = http.StatusInternalServerError, "ERROR: Missing 'to' or 'cam', name: "+name
 		c.Debug.Printf("[%v] Invalid 'to' provided or 'cam' empty: %v", reqID, name)

--- a/pkg/webserver/webhandler_send.go
+++ b/pkg/webserver/webhandler_send.go
@@ -34,7 +34,7 @@ func (c *Config) sendVideoHandler(writer http.ResponseWriter, request *http.Requ
 	cam := c.cameraByName(name)
 	if !c.securitySpyReady() {
 		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
-		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not connected yet"
+		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
 	} else if cam == nil {
 		c.Debug.Printf("[%v] Invalid 'cam' provided: %v", reqID, name)
 		code, reply = http.StatusInternalServerError, "ERROR: Camera not found in configuration!"
@@ -152,7 +152,7 @@ func (c *Config) sendPictureHandler(writer http.ResponseWriter, request *http.Re
 
 	switch {
 	case !c.securitySpyReady():
-		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not connected yet"
+		code, reply = http.StatusServiceUnavailable, "ERROR: SecuritySpy not ready (cameras not loaded)"
 		c.Debug.Printf("[%v] SecuritySpy cameras not loaded yet", reqID)
 	case name == "" || code == http.StatusInternalServerError:
 		code, reply = http.StatusInternalServerError, "ERROR: Missing 'to' or 'cam', name: "+name

--- a/pkg/webserver/webserver.go
+++ b/pkg/webserver/webserver.go
@@ -48,9 +48,7 @@ type Config struct {
 // Start validates the config and returns any errors.
 // If all goes well, this will not return until the server shuts down.
 func Start(cfg *Config) error {
-	if cfg.SSpy == nil {
-		return fmt.Errorf("%w: securityspy is nil", messenger.ErrNillConfigItem)
-	}
+	// SSpy may be nil when [security_spy] is missing; camera routes return 503 via securitySpyReady.
 
 	if cfg.Subs == nil {
 		return fmt.Errorf("%w: subscribe is nil", messenger.ErrNillConfigItem)

--- a/pkg/webserver/webserver.go
+++ b/pkg/webserver/webserver.go
@@ -166,3 +166,17 @@ func (c *Config) handleAll(writer http.ResponseWriter, request *http.Request) {
 func contains(s []string, e string) bool {
 	return slices.Contains(s, e)
 }
+
+// securitySpyReady is false until the first successful Refresh() loads cameras.
+func (c *Config) securitySpyReady() bool {
+	return c != nil && c.SSpy != nil && c.SSpy.Cameras != nil
+}
+
+// cameraByName looks up a camera, or nil when SecuritySpy has no camera list yet.
+func (c *Config) cameraByName(name string) *securityspy.Camera {
+	if !c.securitySpyReady() {
+		return nil
+	}
+
+	return c.SSpy.Cameras.ByName(name)
+}


### PR DESCRIPTION
## Summary
- **Start without SecuritySpy:** finish boot when SS is down; retry with `[motifini] security_spy_retry` (default `5s`); Telegram/HTTP stay up. Missing `[security_spy]` leaves cameras disabled (no dummy localhost client, no event-stream watch) while chat still works.
- **Quieter stream alerts:** only notify on real stream up/down transitions (no spam while never connected); later Refresh failures log at Debug.
- **Motifini Started event:** built-in catalog event; subscribers get a text ping when Motifini finishes booting (after Telegram is ready).
- **Admin per-camera clip settings:** `/camset` (or Cams → Clip settings) stores global `__cam:<name>` profiles — scale (`full` / `½` / `¼`), length (2–15s), size (500KiB–3MiB). Motion and `/vid` share the same profile; values are clamped on read.
- **HEVC scale quirk:** half requests strictly below native/2 (even pixels), e.g. Mailbox 1440 → **718** — exact half (720) makes SecuritySpy stream-copy full frame.
- **Telegram UX:** carbon duration phrases (`1 minute`), delay presets including 10/15/20/90s, Cancel→Done in wizards, chat loggers wired into the app log; pause countdowns round to whole seconds and show `0 seconds` when expired.
- **Nil-safe / HTTP:** camera helpers and 503 when cameras aren’t loaded; picture handler validates inputs before 503; notify can still send text-only while SS is down; config-change guards nil HTTP; clear attach path on SaveJPEG failure.

## Test plan
- [x] Start with SecuritySpy stopped — app stays up, one ERROR, then Debug retries; `/help` works
- [x] Bring SecuritySpy back — cameras refresh; first stream connect does not send a false “back up”
- [x] Kill SecuritySpy after connect — one stream-down notice; reconnect sends stream-up
- [x] Missing `[security_spy]` — app runs without event stream; non-camera chat still works; camera cmds say not ready
- [x] Subscribe to **Motifini Started** — restart Motifini; get a text notification with version/PID
- [x] Admin `/camset` (or Cams → Clip settings) — set Mailbox to ½ / 6s / 1.5MB; motion and `/vid` use it
- [x] `/vid` or motion on Mailbox (1440p HEVC) at ½ → ~1276×718, not full 2560×1440
- [x] `/delay` menu shows 10s/15s/20s/30s/60s/90s/2/5/10 min; lists show “1 minute” style text
- [ ] HTTP `/send/.../video|picture` returns 503 when cameras aren’t loaded (after bad `to`/`cam` is rejected); notify without cameras still delivers text