### PR TITLE
Rewrite README as SecuritySpy Telegram Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Motifini — SecuritySpy Telegram Bot
 
-Motifini is a small daemon that connects [SecuritySpy](https://www.bensoftware.com/securityspy/) to a Telegram bot.
+Motifini is a small daemon that connects [SecuritySpy](https://www.bensoftware.com/securityspy/) to a Telegram bot — with a full interactive menu, not just slash commands.
 
-When a camera triggers motion (or human / vehicle / animal classification), Motifini captures a short live clip and sends it to whoever subscribed to that camera in Telegram. You can also pull a snapshot or clip on demand, pause alerts, set repeat delays, and get text pings for system events (app started, event stream up/down, cameras online/offline).
+When a camera triggers motion (or human / vehicle / animal classification), Motifini captures a short live clip and sends it to whoever subscribed to that camera. Each person configures their own subscriptions, pauses, and repeat delays. Admins tune per-camera clip quality for everyone. Snapshots, on-demand video, and system events (app started, event stream up/down, cameras online/offline) are all a tap away in Telegram.
 
 It starts even if SecuritySpy is temporarily down, retries in the background, and keeps the Telegram bot usable meanwhile. Video capture is pure Go (no ffmpeg binary).
 
@@ -25,6 +25,8 @@ It starts even if SecuritySpy is temporarily down, retries in the background, an
 
 ## Using the bot
 
+The Telegram UI is a full-blown button menu. Browse cameras, subscribe to events, pause alerts, set delays, pull a snapshot or clip — almost everything is tappable. Slash commands still work if you prefer typing (`/sub`, `/subs`, `/stop`, `/delay`, `/cams`, `/pics`, `/vid`, …); `/help` lists them.
+
 **Allowing users**
 
 New chats get no reply until they are allowed:
@@ -36,9 +38,18 @@ New chats get no reply until they are allowed:
 
 Display name when someone has no `@username`: `/name <chatId> Jane Doe` (aliases: `/rename`, `/nick`).
 
-**Subscriptions**
+**Per-subscriber configuration**
 
-Use the Telegram menus or commands (`/sub`, `/subs`, `/stop`, `/delay`, Events) to subscribe to cameras and classification filters, pause alerts, and set how often repeat clips are sent for the same subscription.
+Every allowed chat has its own settings. One person can watch the driveway for cars, another only humans at the front door, and a third can pause the porch for an hour — without affecting anyone else.
+
+- Subscribe / unsubscribe per camera and classification (motion, human, vehicle, animal), or to named system events
+- Per-subscription repeat delay (how long before another clip for the same trigger)
+- Pause all alerts or a single camera (`/stop` / menu), then resume when ready
+- On-demand snapshot or video from any camera you can see
+
+**Per-camera clip settings** (admins — `/camset` or Cams → camera → Clip settings)
+
+Clip quality is shared for that camera (motion alerts and `/vid`): scale (full / half / quarter), length (2–15s), and max size (500k–3MB). Half requests slightly under half native height so SecuritySpy recompresses HEVC instead of stream-copying the full frame.
 
 **Built-in system events** (subscribe like any other event)
 
@@ -46,10 +57,6 @@ Use the Telegram menus or commands (`/sub`, `/subs`, `/stop`, `/delay`, Events) 
 - Event Stream Up / Down
 - Camera Online / Offline
 - SecuritySpy Error
-
-**Admin: per-camera clip settings** (`/camset` or Cams → Clip settings)
-
-Everyone gets the same clip for a camera. Admins set scale (full / half / quarter), length (2–15s), and max size (500k–3MB). Half requests slightly under half native height so SecuritySpy recompresses HEVC instead of stream-copying the full frame.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,146 +1,60 @@
-# Motifini
+# Motifini — SecuritySpy Telegram Bot
 
-This application has a few features.
+Motifini is a small daemon that connects [SecuritySpy](https://www.bensoftware.com/securityspy/) to a Telegram bot.
 
-- Send Telegram messages via an optional HTTP API.
-- Captures short SecuritySpy video clips in pure Go (no ffmpeg binary).
-- Subscribe to motion / human / vehicle / animal notifications on SecuritySpy cameras.
-- Receive alert videos in Telegram when something happens.
-- SecuritySpy is required; Telegram is the notification channel.
+When a camera triggers motion (or human / vehicle / animal classification), Motifini captures a short live clip and sends it to whoever subscribed to that camera in Telegram. You can also pull a snapshot or clip on demand, pause alerts, set repeat delays, and get text pings for system events (app started, event stream up/down, cameras online/offline).
 
-My wife and I use this to receive videos in Telegram for cameras we care about.
-I have a couple other family members relying on this app; they also use SecuritySpy.
+It starts even if SecuritySpy is temporarily down, retries in the background, and keeps the Telegram bot usable meanwhile. Video capture is pure Go (no ffmpeg binary).
 
-## SecuritySpy
+## Quick start
 
-This library taps into the SecuritySpy API and Event Stream. You do not need to do
-much besides provide a URL. You can then subscribe to any camera.
-It works with Telegram.
+1. Create a SecuritySpy web account with access to your cameras.
+2. Create a Telegram bot with [@BotFather](https://t.me/BotFather).
+3. Copy the example config and fill in URL, credentials, bot token, and password:
 
-Add an account to securityspy, and give it access to your cameras.
-I probably used admin, but you can certainly tune the permissions.
-Sorry, I do not know what they are right now. :(
+   [`https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example`](https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example)
 
-Put the url, username and password into the config file.
+   Default path: `/usr/local/etc/motifini.conf` (or `--config=/path/to/file`).
 
-## Telegram
+4. Run Motifini, then message the bot:
 
-Add a bot token and set a password in the config.
-Once the app fires up, message your bot `/id <password>`.
-Then message it `/help`.
+   ```text
+   /id <telegram.password>
+   /help
+   ```
 
-New users who message without auth are logged and get **no reply** until they are allowed:
+## Using the bot
 
-1. **Self-serve:** they send `/id <telegram.password>` (from config), or
-2. **Admin:** after they message once, you send `/allow <telegramIdOrUsername>` (also `/auth`).
-   Revoke with `/deny <id>`.
+**Allowing users**
 
-`/admin <user>` only grants admin commands; it does **not** unlock the bot. Use `/allow` for that.
+New chats get no reply until they are allowed:
 
-Set a display name when someone has no Telegram `@username`:
+1. Self-serve: `/id <password>` (from config), or
+2. Admin: after they message once, `/allow <telegramIdOrUsername>` (also `/auth`). Revoke with `/deny <id>`.
 
-```text
-/name <chatId> Jane Doe
-```
+`/admin <user>` grants admin commands only; it does **not** unlock the bot — use `/allow` for that.
 
-Aliases: `/rename`, `/nick`.
+Display name when someone has no `@username`: `/name <chatId> Jane Doe` (aliases: `/rename`, `/nick`).
 
-## Example Config File
+**Subscriptions**
 
-Only Telegram chat IDs listed in `allowed_to` can receive messages from the HTTP API.
+Use the Telegram menus or commands (`/sub`, `/subs`, `/stop`, `/delay`, Events) to subscribe to cameras and classification filters, pause alerts, and set how often repeat clips are sent for the same subscription.
 
-- Location: `/usr/local/etc/motifini.conf`
-- Example: [examples/motifini.conf.example](examples/motifini.conf.example)
+**Built-in system events** (subscribe like any other event)
 
-Optional `[motifini]` settings:
+- Motifini Started
+- Event Stream Up / Down
+- Camera Online / Offline
+- SecuritySpy Error
 
-- `debug` — verbose Telegram/HTTP diagnostics (also written to `log_file` when set)
-- `log_file` — path for a rotating app log (when set, further logs leave stdout/stderr; config and log paths are still printed to stdout first)
-- `event_log` — path for a rotating SecuritySpy event-stream log (omit to disable; must differ from `log_file`)
-- `log_file_mb` — max size per rotated log file in MB (default `5`)
-- `log_files` — number of rotated log files to keep (default `10`)
-- `security_spy_retry` — how often to retry connecting when SecuritySpy is down at startup (Go duration, default `5s`)
+**Admin: per-camera clip settings** (`/camset` or Cams → Clip settings)
 
-Built-in system events (subscribe via Events / `/sub`):
+Everyone gets the same clip for a camera. Admins set scale (full / half / quarter), length (2–15s), and max size (500k–3MB). Half requests slightly under half native height so SecuritySpy recompresses HEVC instead of stream-copying the full frame.
 
-- **Motifini Started** — text notification when Motifini finishes booting (Telegram ready)
-- Event Stream Up / Down, Camera Online / Offline, SecuritySpy Error
+## Configuration
 
-Admin Telegram commands:
+All options are documented in the example file:
 
-- `/camset` (aka `/clipset`) — per-camera clip profile used for motion alerts and `/vid` (everyone gets the same clip)
-  - **Scale:** full / half / quarter of native resolution (default half)
-  - **Length:** 2–15 seconds (default 6s)
-  - **Size:** 500k–3MB max file size (default 1.5MB)
-  - Also available from **Cameras → camera → Clip settings** for admins
+[`https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example`](https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example)
 
-## HTTP Endpoints
-
-If you enable the webserver, these are (some) of the endpoints.
-
-- /api/v1.0/send/telegram/video/{to}/{camera}
-Captures a short live clip from SecuritySpy (no ffmpeg binary).
-  - **`to` (csv), list of message recipients**
-  - **`camera` (string), camera name**
-  - `width` (int), frame size
-  - `height` (int), frame size
-  - `crf` / quality (int)
-  - `time` (duration or seconds), max video length
-  - `rate` (int), output frame rate
-  - `size` (int), max file size
-
-- /api/v1.0/send/telegram/picture/{to}/{camera}
-Snapshot from SecuritySpy.
-  - **`to` (csv), list of message recipients**
-  - **`camera` (string), camera name**
-
-- /api/v1.0/send/telegram/msg/{to}?msg={msg}
-Plain Telegram text.
-  - **`to` (csv), list of message recipients**
-  - **`msg` (string), text to send**
-
-- /api/v1.0/sub/{subscribe|unsubscribe|pause|unpause}/{api}/{contact}/{event}
-Manage a subscriber's event subscription (Telegram `api` + chat id or contact name).
-  - `minutes` (pause only, default `60`)
-
-- /api/v1.0/event/{notify|remove}/{event}
-Notify subscribers of a named event (optional camera snapshot when the name matches a camera),
-or remove an event and all its subscriptions.
-
-- /debug/vars
-expvar stats (HTTP counts, subscribers, cameras, …).
-
-## IndigoDomo
-
-This is an example showing how to trigger this app to send a picture or
-message to someone via Telegram from [Indigo](http://indigodomo.com).
-This works, and also works with Telegram now.
-You can directly trigger "send a picture or video snippet to someone
-via telegram" by hitting an http endpoint as shown here.
-
-Create two variables in Indigo.
-Name one variable `Subscribers` and the other `SendMessage`
-Create a trigger when `SendMessage` changes to run an Action.
-
-Run this Action; replace the variable IDs with your own:
-
-```python
-import urllib
-import urllib2
-import socket
-timeout = 1
-socket.setdefaulttimeout(timeout)
-
-subs = urllib.quote(indigo.variables[1891888064].value, "")
-msg = urllib.quote(indigo.variables[1023892794].value, "")
-url = "http://127.0.0.1:8765/api/v1.0/send/telegram/msg/"+subs+"?msg="+msg
-
-try:
-    urllib2.urlopen(url)
-    indigo.server.log(u"Dropped off message with Motifini!")
-except Exception as err:
-    indigo.server.log(u"Error with Motifini: {}".format(err))
-```
-
-Subscriptions and motion classifications are managed in Telegram (`/sub`, `/subs`, `/stop`, `/delay`).
-Home automation can still fire notifications via the HTTP endpoints above.
+Environment variables can override config values with prefix `MO_` (change with `--prefix`).

--- a/examples/motifini.conf.example
+++ b/examples/motifini.conf.example
@@ -1,0 +1,74 @@
+# Motifini — SecuritySpy Telegram Bot
+# Copy to /usr/local/etc/motifini.conf (or pass --config=...) and fill in secrets.
+# Environment overrides use prefix MO_ by default (e.g. MO_TELEGRAM_TOKEN).
+
+##############################################################################
+# App paths, logging, and SecuritySpy reconnect
+##############################################################################
+[motifini]
+  # Where short video/photo temps are written before Telegram upload.
+  temp_dir = "/tmp"
+
+  # Subscriber DB (who is allowed, subscriptions, per-camera clip settings, etc.).
+  state_file = "/usr/local/var/lib/motifini-subscribers.json"
+
+  # Optional rotating app log (info/error/debug). Empty = stdout/stderr only.
+  # When set, further logs leave the console (config/log paths still print first).
+  log_file = "/usr/local/var/log/motifini/motifini.log"
+
+  # Optional rotating SecuritySpy event-stream log. Empty = disabled.
+  # Must be a different path from log_file.
+  event_log = "/usr/local/var/log/motifini/events.log"
+
+  # Rotated log size / retention (also used for event_log when set).
+  log_file_mb = 5   # max size per file in megabytes (default 5)
+  log_files   = 10  # number of rotated files to keep (default 10)
+
+  # How often to retry Refresh when SecuritySpy is down at startup (Go duration).
+  # Motifini still boots and Telegram stays available while retrying.
+  security_spy_retry = "5s"
+
+  # Verbose Telegram/HTTP diagnostics (also written to log_file when set).
+  debug = false
+
+##############################################################################
+# Optional localhost HTTP API (disabled by default)
+# Kept for local automation; not required for normal Telegram bot use.
+##############################################################################
+[webserver]
+  enable = false
+  # Listens on 127.0.0.1 only.
+  port = 8765
+  # Telegram chat IDs (as strings) allowed as HTTP "to" recipients.
+  allowed_to = [
+    # "123456789",
+  ]
+
+##############################################################################
+# Telegram bot (required for notifications / commands)
+# Create a bot with @BotFather, then put the token here.
+##############################################################################
+[telegram]
+  token = "123456:ABC-DEF..."
+  # Shared password for /id <password> so new users can unlock the bot.
+  password = "change-me"
+  # Extra Telegram API debug (noisy).
+  debug = false
+
+##############################################################################
+# SecuritySpy (required for cameras / motion clips)
+# Create a SecuritySpy web-server user with access to the cameras you want.
+# Motifini starts even if SecuritySpy is temporarily unreachable.
+##############################################################################
+[security_spy]
+  url      = "https://192.168.1.10:8001/"
+  username = "motifini"
+  password = "change-me"
+  # Require a valid TLS certificate for the SecuritySpy URL (default false = skip verify).
+  # Note: this library field has no snake_case tag — use "verifyssl", not "verify_ssl".
+  verifyssl = false
+  # HTTP client timeout for API calls (Go duration; default 10s if omitted).
+  timeout = "10s"
+  # Retries for still-image fetches (default 3 if omitted or <= 0).
+  # Note: use "jpegretries", not "jpeg_retries".
+  jpegretries = 3


### PR DESCRIPTION
## Summary
- Rewrite README to describe Motifini as a SecuritySpy Telegram bot (setup, allowing users, subscriptions, system events, admin clip settings)
- Add fully commented `examples/motifini.conf.example` and link it with the full GitHub URL
- Remove config option lists, HTTP API docs, and the IndigoDomo section from the README

## Test plan
- [ ] Open the example config link from the README on GitHub after merge
- [ ] Confirm example covers `[motifini]`, `[webserver]`, `[telegram]`, and `[security_spy]` options


Made with [Cursor](https://cursor.com)