### PR TITLE
Add GoReleaser + Homebrew tap publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,17 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          # Notarization can take a while when wait=true.
+          args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Fine-grained PAT with Contents: R/W on golift/homebrew-mugs.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           USER: github-actions
+          # Apple Developer ID Application .p12 (base64) + password.
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          # App Store Connect API key (.p8 base64), key id, and issuer UUID.
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Set revision
+        run: echo "REVISION=$(git rev-list --count --all || echo 0)" >> "$GITHUB_ENV"
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained PAT with Contents: R/W on golift/homebrew-mugs.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          USER: github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Set revision
-        run: echo "REVISION=$(git rev-list --count --all || echo 0)" >> "$GITHUB_ENV"
+        # Count commits reachable from the tagged HEAD (stable across checkouts).
+        run: echo "REVISION=$(git rev-list --count HEAD || echo 0)" >> "$GITHUB_ENV"
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Change this line.
 /motifini
+/dist/
 /init/macos/*.app/Contents/MacOS/*
 # The rest is probably fine.
 /rsrc*.syso

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: motifini
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: motifini
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - freebsd
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X "golift.io/version.Version={{.Version}}"
+      - -X "golift.io/version.BuildDate={{.Date}}"
+      - -X "golift.io/version.BuildUser={{.Env.USER}}"
+      - -X "golift.io/version.Revision={{.Env.REVISION}}"
+      - -X "golift.io/version.Branch={{.ShortCommit}} [{{.Branch}}]"
+
+universal_binaries:
+  - id: motifini
+    replace: true
+
+archives:
+  - id: motifini
+    formats: [tar.gz]
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+      - examples/motifini.conf.example
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: checksums.txt
+
+brews:
+  - name: motifini
+    repository:
+      owner: golift
+      name: homebrew-mugs
+      branch: master
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    directory: Formula
+    homepage: https://github.com/davidnewhall/motifini
+    description: SecuritySpy Telegram Bot — motion clips and camera alerts in Telegram
+    license: MIT
+    url_template: "https://github.com/davidnewhall/motifini/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    install: |
+      bin.install "motifini"
+      etc.install "examples/motifini.conf.example" => "motifini.conf.example"
+    service: |
+      run [opt_bin/"motifini", "--config", etc/"motifini.conf"]
+      keep_alive true
+      log_path var/"log/motifini.log"
+      error_log_path var/"log/motifini.log"
+    caveats: |
+      Copy the example config, then edit it:
+        cp #{etc}/motifini.conf.example #{etc}/motifini.conf
+      Start with brew services:
+        brew services start motifini
+    test: |
+      assert_match "motifini, version #{version}", shell_output("#{bin}/motifini -v 2>&1")
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,23 @@ universal_binaries:
   - id: motifini
     replace: true
 
+# Sign + notarize the macOS universal binary (quill; works on Linux CI).
+# Enabled only when MACOS_SIGN_P12 is set so local snapshots still work.
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - motifini
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+        wait: true
+        timeout: 20m
+
 archives:
   - id: motifini
     formats: [tar.gz]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ When a camera triggers motion (or human / vehicle / animal classification), Moti
 
 It starts even if SecuritySpy is temporarily down, retries in the background, and keeps the Telegram bot usable meanwhile. Video capture is pure Go (no ffmpeg binary).
 
+## Install
+
+macOS (Homebrew tap):
+
+```bash
+brew install golift/mugs/motifini
+cp "$(brew --prefix)/etc/motifini.conf.example" "$(brew --prefix)/etc/motifini.conf"
+# edit the config, then:
+brew services start motifini
+```
+
+Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
+[GitHub Releases](https://github.com/davidnewhall/motifini/releases) after tagging `v*`.
+
 ## Quick start
 
 1. Create a SecuritySpy web account with access to your cameras.
@@ -14,7 +28,7 @@ It starts even if SecuritySpy is temporarily down, retries in the background, an
 
    [`https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example`](https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example)
 
-   Default path: `/usr/local/etc/motifini.conf` (or `--config=/path/to/file`).
+   Default path: `/usr/local/etc/motifini.conf` (or `--config=/path/to/file`). Homebrew uses `$(brew --prefix)/etc/motifini.conf`.
 
 4. Run Motifini, then message the bot:
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,21 @@ macOS (Homebrew tap):
 ```bash
 brew install golift/mugs/motifini
 cp "$(brew --prefix)/etc/motifini.conf.example" "$(brew --prefix)/etc/motifini.conf"
-# edit the config, then:
+# edit the config (token, SecuritySpy URL, etc.), then:
 brew services start motifini
 ```
 
+The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew`
+(`state_file`, `log_file`, `event_log`). If `brew --prefix` is `/usr/local` (Intel)
+or anything else, change those paths to match — e.g. `$(brew --prefix)/var/...` —
+before starting, or Motifini may fail to write state/logs.
+
+`brew services` passes `--config=$(brew --prefix)/etc/motifini.conf` explicitly.
+Running `motifini` by hand without `--config` uses the binary default
+`/opt/homebrew/etc/motifini.conf`.
+
 Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
-[GitHub Releases](https://github.com/davidnewhall/motifini/releases) after tagging `v*`.
+[GitHub Releases](https://github.com/davidnewhall/motifini/releases).
 
 ## Quick start
 
@@ -28,7 +37,9 @@ Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
 
    [`https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example`](https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example)
 
-   Default path: `/usr/local/etc/motifini.conf` (or `--config=/path/to/file`). Homebrew uses `$(brew --prefix)/etc/motifini.conf`.
+   Default config path (no flags): `/opt/homebrew/etc/motifini.conf`. Override with
+   `--config=/path/to/file`. After `brew install`, prefer
+   `$(brew --prefix)/etc/motifini.conf` (what `brew services` uses).
 
 4. Run Motifini, then message the bot:
 

--- a/examples/motifini.conf.example
+++ b/examples/motifini.conf.example
@@ -1,5 +1,7 @@
 # Motifini — SecuritySpy Telegram Bot
-# Copy to /usr/local/etc/motifini.conf (or pass --config=...) and fill in secrets.
+# Copy to /opt/homebrew/etc/motifini.conf (or pass --config=...) and fill in secrets.
+# Apple Silicon Homebrew prefix is /opt/homebrew; Intel may still use /usr/local —
+# or substitute $(brew --prefix) for etc/var paths below.
 # Environment overrides use prefix MO_ by default (e.g. MO_TELEGRAM_TOKEN).
 
 ##############################################################################
@@ -10,15 +12,15 @@
   temp_dir = "/tmp"
 
   # Subscriber DB (who is allowed, subscriptions, per-camera clip settings, etc.).
-  state_file = "/usr/local/var/lib/motifini-subscribers.json"
+  state_file = "/opt/homebrew/var/lib/motifini-subscribers.json"
 
   # Optional rotating app log (info/error/debug). Empty = stdout/stderr only.
   # When set, further logs leave the console (config/log paths still print first).
-  log_file = "/usr/local/var/log/motifini/motifini.log"
+  log_file = "/opt/homebrew/var/log/motifini/motifini.log"
 
   # Optional rotating SecuritySpy event-stream log. Empty = disabled.
   # Must be a different path from log_file.
-  event_log = "/usr/local/var/log/motifini/events.log"
+  event_log = "/opt/homebrew/var/log/motifini/events.log"
 
   # Rotated log size / retention (also used for event_log when set).
   log_file_mb = 5   # max size per file in megabytes (default 5)

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -99,7 +99,7 @@ func (flag *Flags) ParseArgs(args []string) {
 	}
 
 	flag.StringVarP(&flag.EnvPrefix, "prefix", "p", DefaultEnvPrefix, "Environment Variable Configuration Prefix")
-	flag.StringVarP(&flag.ConfigFile, "config", "c", "/usr/local/etc/"+Binary+".conf", "Config File")
+	flag.StringVarP(&flag.ConfigFile, "config", "c", "/opt/homebrew/etc/"+Binary+".conf", "Config File")
 	flag.BoolVarP(&flag.VersionReq, "version", "v", false, "Print the version and exit")
 	_ = flag.Parse(args) // flag.ExitOnError means this will never return != nil
 }


### PR DESCRIPTION
## Summary
- Tag-only GitHub Actions release via GoReleaser (`v*` tags)
- Archives for Linux, FreeBSD, Windows (amd64/arm64) and macOS universal (`darwin_all`)
- Publishes `Formula/motifini.rb` to [golift/homebrew-mugs](https://github.com/golift/homebrew-mugs) using `HOMEBREW_TAP_GITHUB_TOKEN`
- README install notes for `brew install golift/mugs/motifini`

## Before first release
1. Create a fine-grained PAT with **Contents: Read and write** on `golift/homebrew-mugs`
2. Add it as repo secret `HOMEBREW_TAP_GITHUB_TOKEN` on `davidnewhall/motifini`
3. Merge this PR, then `git tag v0.0.7 && git push origin v0.0.7` (or next version)

## Test plan
- [x] `goreleaser check`
- [x] `goreleaser release --snapshot --skip=publish` (universal binary + all archives)
- [ ] After secret is set: push a `v*` tag and confirm GitHub Release assets + tap formula update


Made with [Cursor](https://cursor.com)