### PR TITLE
Fix Homebrew cask for Brew 6 + LaunchAgent control

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,7 +96,7 @@ homebrew_casks:
           FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf.example"
           FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf" unless (conf_dir/"motifini.conf").exist?
           (HOMEBREW_PREFIX/"var/log").mkpath
-          label = "com.davidnewhall.motifini"
+          label = "io.golift.motifini"
           agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
           agent.dirname.mkpath
           binary = HOMEBREW_PREFIX/"bin/motifini"
@@ -123,15 +123,15 @@ homebrew_casks:
             </plist>
           XML
         uninstall: |
-          label = "com.davidnewhall.motifini"
+          label = "io.golift.motifini"
           agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
           system "/bin/launchctl", "bootout", "gui/#{Process.uid}", label
           agent.delete if agent.exist?
     caveats: |
       Edit #{HOMEBREW_PREFIX}/etc/motifini.conf then:
-        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
-      Restart: launchctl kickstart -k gui/$(id -u)/com.davidnewhall.motifini
-      Stop:    launchctl bootout gui/$(id -u)/com.davidnewhall.motifini
+        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist
+      Restart: launchctl kickstart -k gui/$(id -u)/io.golift.motifini
+      Stop:    launchctl bootout gui/$(id -u)/io.golift.motifini
       (brew services does not manage casks.)
 
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,8 @@ notarize:
 archives:
   - id: motifini
     formats: [tar.gz]
-    wrap_in_directory: true
+    # Flat archives so Homebrew casks can find binary/examples without rename.
+    wrap_in_directory: false
     files:
       - LICENSE
       - README.md
@@ -80,24 +81,21 @@ homebrew_casks:
     commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
     directory: Casks
     homepage: https://github.com/davidnewhall/motifini
-    description: SecuritySpy Telegram Bot — motion clips and camera alerts in Telegram
+    description: SecuritySpy Telegram Bot - motion clips and camera alerts in Telegram
     license: MIT
     url:
       template: "https://github.com/davidnewhall/motifini/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    service: |
-      run ["#{opt_bin}/motifini", "--config", "#{etc}/motifini.conf"]
-      keep_alive true
-      log_path "#{var}/log/motifini.log"
-      error_log_path "#{var}/log/motifini.log"
+      verified: github.com/davidnewhall/motifini
+    # Do not set `service:` — on Homebrew 6+ cask `service` is a Moved artifact (plist path),
+    # not Formula's `service do` block. GoReleaser's quoted service string also breaks Ruby parse.
     hooks:
       post:
         install: |
-          FileUtils.cp "#{staged_path}/examples/motifini.conf.example", "#{etc}/motifini.conf.example"
-          FileUtils.cp "#{staged_path}/examples/motifini.conf.example", "#{etc}/motifini.conf" unless File.exist?("#{etc}/motifini.conf")
-    caveats: |
-      Edit #{etc}/motifini.conf (example copied on install), then:
-        brew services start motifini
-      State/log paths in the example default to /opt/homebrew/var/... — adjust if brew --prefix differs.
+          conf_dir = HOMEBREW_PREFIX/"etc"
+          conf_dir.mkpath
+          FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf.example"
+          FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf" unless (conf_dir/"motifini.conf").exist?
+    caveats: "Edit #{HOMEBREW_PREFIX}/etc/motifini.conf then run: motifini --config=#{HOMEBREW_PREFIX}/etc/motifini.conf. Example state/log paths use /opt/homebrew/var/...; adjust if brew --prefix differs."
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,8 +86,8 @@ homebrew_casks:
     url:
       template: "https://github.com/davidnewhall/motifini/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
       verified: github.com/davidnewhall/motifini
-    # Do not set `service:` — on Homebrew 6+ cask `service` is a Moved artifact (plist path),
-    # not Formula's `service do` block. GoReleaser's quoted service string also breaks Ruby parse.
+    # Do not set `service:` — cask `service` is ~/Library/Services (Automator), not LaunchAgents.
+    # Install a LaunchAgent in postflight; manage with launchctl (brew services is formula-only).
     hooks:
       post:
         install: |
@@ -95,7 +95,44 @@ homebrew_casks:
           conf_dir.mkpath
           FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf.example"
           FileUtils.cp "#{staged_path}/examples/motifini.conf.example", conf_dir/"motifini.conf" unless (conf_dir/"motifini.conf").exist?
-    caveats: "Edit #{HOMEBREW_PREFIX}/etc/motifini.conf then run: motifini --config=#{HOMEBREW_PREFIX}/etc/motifini.conf. Example state/log paths use /opt/homebrew/var/...; adjust if brew --prefix differs."
+          (HOMEBREW_PREFIX/"var/log").mkpath
+          label = "com.davidnewhall.motifini"
+          agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
+          agent.dirname.mkpath
+          binary = HOMEBREW_PREFIX/"bin/motifini"
+          conf = conf_dir/"motifini.conf"
+          log = HOMEBREW_PREFIX/"var/log/motifini.log"
+          agent.write <<~XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>#{label}</string>
+              <key>ProgramArguments</key>
+              <array>
+                <string>#{binary}</string>
+                <string>--config</string>
+                <string>#{conf}</string>
+              </array>
+              <key>RunAtLoad</key><true/>
+              <key>KeepAlive</key><true/>
+              <key>WorkingDirectory</key><string>#{HOMEBREW_PREFIX}</string>
+              <key>StandardOutPath</key><string>#{log}</string>
+              <key>StandardErrorPath</key><string>#{log}</string>
+            </dict>
+            </plist>
+          XML
+        uninstall: |
+          label = "com.davidnewhall.motifini"
+          agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
+          system "/bin/launchctl", "bootout", "gui/#{Process.uid}", label
+          agent.delete if agent.exist?
+    caveats: |
+      Edit #{HOMEBREW_PREFIX}/etc/motifini.conf then:
+        launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
+      Restart: launchctl kickstart -k gui/$(id -u)/com.davidnewhall.motifini
+      Stop:    launchctl bootout gui/$(id -u)/com.davidnewhall.motifini
+      (brew services does not manage casks.)
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,7 +125,7 @@ homebrew_casks:
         uninstall: |
           label = "io.golift.motifini"
           agent = Pathname.new(Dir.home)/"Library/LaunchAgents/#{label}.plist"
-          system "/bin/launchctl", "bootout", "gui/#{Process.uid}", label
+          system "/bin/launchctl", "bootout", "gui/#{Process.uid}/#{label}"
           agent.delete if agent.exist?
     caveats: |
       Edit #{HOMEBREW_PREFIX}/etc/motifini.conf then:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macOS (Homebrew tap):
 ```bash
 brew install --cask golift/mugs/motifini
 # edit $(brew --prefix)/etc/motifini.conf (copied from the example on install), then:
-brew services start motifini
+motifini --config="$(brew --prefix)/etc/motifini.conf"
 ```
 
 The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew`
@@ -21,9 +21,9 @@ The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew
 or anything else, change those paths to match — e.g. `$(brew --prefix)/var/...` —
 before starting, or Motifini may fail to write state/logs.
 
-`brew services` passes `--config=$(brew --prefix)/etc/motifini.conf` explicitly.
-Running `motifini` by hand without `--config` uses the binary default
-`/opt/homebrew/etc/motifini.conf`.
+Homebrew casks do not support Formula-style `brew services`; run Motifini in the
+foreground (or under your own launchd unit). Running without `--config` uses the
+binary default `/opt/homebrew/etc/motifini.conf`.
 
 Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
 [GitHub Releases](https://github.com/davidnewhall/motifini/releases).
@@ -37,8 +37,8 @@ Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
    [`https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example`](https://github.com/davidnewhall/motifini/blob/main/examples/motifini.conf.example)
 
    Default config path (no flags): `/opt/homebrew/etc/motifini.conf`. Override with
-   `--config=/path/to/file`. After `brew install`, prefer
-   `$(brew --prefix)/etc/motifini.conf` (what `brew services` uses).
+   `--config=/path/to/file`. After `brew install --cask`, prefer
+   `$(brew --prefix)/etc/motifini.conf`.
 
 4. Run Motifini, then message the bot:
 
@@ -49,7 +49,8 @@ Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
 
 ## Using the bot
 
-The Telegram UI is a full-blown button menu. Browse cameras, subscribe to events, pause alerts, set delays, pull a snapshot or clip — almost everything is tappable. Slash commands still work if you prefer typing (`/sub`, `/subs`, `/stop`, `/delay`, `/cams`, `/pics`, `/vid`, …); `/help` lists them.
+The Telegram UI is a full-blown button menu. Browse cameras, subscribe to events, pause alerts, set delays, pull a snapshot or clip — almost everything is tappable.
+Slash commands still work if you prefer typing (`/sub`, `/subs`, `/stop`, `/delay`, `/cams`, `/pics`, `/vid`, …); `/help` lists them.
 
 **Allowing users**
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ macOS (Homebrew tap):
 ```bash
 brew install --cask golift/mugs/motifini
 # edit $(brew --prefix)/etc/motifini.conf, then:
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist
 ```
 
 The cask installs a LaunchAgent plist (not started until you bootstrap it). Control it with:
 
 ```bash
 # start / load at login
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist
 # restart
-launchctl kickstart -k gui/$(id -u)/com.davidnewhall.motifini
+launchctl kickstart -k gui/$(id -u)/io.golift.motifini
 # stop
-launchctl bootout gui/$(id -u)/com.davidnewhall.motifini
+launchctl bootout gui/$(id -u)/io.golift.motifini
 ```
 
 `brew services` only manages formulae, not casks — use `launchctl` above.

--- a/README.md
+++ b/README.md
@@ -12,18 +12,30 @@ macOS (Homebrew tap):
 
 ```bash
 brew install --cask golift/mugs/motifini
-# edit $(brew --prefix)/etc/motifini.conf (copied from the example on install), then:
-motifini --config="$(brew --prefix)/etc/motifini.conf"
+# edit $(brew --prefix)/etc/motifini.conf, then:
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
 ```
+
+The cask installs a LaunchAgent plist (not started until you bootstrap it). Control it with:
+
+```bash
+# start / load at login
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.davidnewhall.motifini.plist
+# restart
+launchctl kickstart -k gui/$(id -u)/com.davidnewhall.motifini
+# stop
+launchctl bootout gui/$(id -u)/com.davidnewhall.motifini
+```
+
+`brew services` only manages formulae, not casks — use `launchctl` above.
 
 The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew`
 (`state_file`, `log_file`, `event_log`). If `brew --prefix` is `/usr/local` (Intel)
 or anything else, change those paths to match — e.g. `$(brew --prefix)/var/...` —
 before starting, or Motifini may fail to write state/logs.
 
-Homebrew casks do not support Formula-style `brew services`; run Motifini in the
-foreground (or under your own launchd unit). Running without `--config` uses the
-binary default `/opt/homebrew/etc/motifini.conf`.
+Running without `--config` uses the binary default `/opt/homebrew/etc/motifini.conf`.
+Logs from the LaunchAgent go to `$(brew --prefix)/var/log/motifini.log`.
 
 Or download binaries for macOS (universal), Linux, FreeBSD, and Windows from
 [GitHub Releases](https://github.com/davidnewhall/motifini/releases).


### PR DESCRIPTION
## Summary
- Fix the Homebrew cask for Homebrew 6: drop invalid `service` stanza, use `HOMEBREW_PREFIX`, flat archives for future releases
- Install a LaunchAgent from cask postflight so Motifini can be started/stopped with `launchctl` (since `brew services` is formula-only)
- Update README with install and launchctl usage

## Test plan
- [x] `brew reinstall --cask golift/mugs/motifini` installs LaunchAgent plist
- [x] `motifini -v` / Gatekeeper Allow works on macOS
- [x] `launchctl bootstrap` / `kickstart` / `bootout` as documented in README


Made with [Cursor](https://cursor.com)