### PR TITLE
Add macOS --start/--stop/--restart LaunchAgent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist
 The cask installs a LaunchAgent plist (not started until you bootstrap it). Control it with:
 
 ```bash
-# start / load at login
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist
-# restart
-launchctl kickstart -k gui/$(id -u)/io.golift.motifini
-# stop
-launchctl bootout gui/$(id -u)/io.golift.motifini
+motifini --start    # load at login / start now
+motifini --restart  # restart the running agent
+motifini --stop     # unload / stop
 ```
 
-`brew services` only manages formulae, not casks — use `launchctl` above.
+These wrap the same `launchctl` calls (`bootstrap` / `kickstart -k` / `bootout` for
+`gui/$(id -u)/io.golift.motifini`). `brew services` only manages formulae, not casks.
 
 The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew`
 (`state_file`, `log_file`, `event_log`). If `brew --prefix` is `/usr/local` (Intel)

--- a/pkg/motifini/start.go
+++ b/pkg/motifini/start.go
@@ -1,6 +1,7 @@
 package motifini
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +15,7 @@ import (
 	"github.com/davidnewhall/motifini/pkg/chat"
 	"github.com/davidnewhall/motifini/pkg/export"
 	"github.com/davidnewhall/motifini/pkg/messenger"
+	"github.com/davidnewhall/motifini/pkg/service"
 	"github.com/davidnewhall/motifini/pkg/webserver"
 	"github.com/spf13/pflag"
 	"golift.io/cnfg"
@@ -25,6 +27,9 @@ import (
 	"golift.io/subscribe"
 	"golift.io/version"
 )
+
+// ErrMultipleServiceFlags is returned when more than one of --start/--stop/--restart is set.
+var ErrMultipleServiceFlags = errors.New("use only one of --start, --stop, or --restart")
 
 // Application identity and default timing values.
 const (
@@ -66,6 +71,9 @@ type Flags struct {
 	EnvPrefix  string
 	ConfigFile string
 	VersionReq bool
+	StartReq   bool
+	StopReq    bool
+	RestartReq bool
 }
 
 // Config is the configuration for Motifini.
@@ -94,14 +102,49 @@ func (flag *Flags) ParseArgs(args []string) {
 	*flag = Flags{FlagSet: pflag.NewFlagSet(Binary, pflag.ExitOnError)}
 
 	flag.Usage = func() {
-		fmt.Printf("Usage: %s [--config=filepath] [--version] [--debug]", Binary) //nolint:forbidigo // cli usage
+		fmt.Printf("Usage: %s [--config=filepath] [--version] "+ //nolint:forbidigo // cli usage
+			"[--start|--stop|--restart]\n", Binary)
 		flag.PrintDefaults()
 	}
 
 	flag.StringVarP(&flag.EnvPrefix, "prefix", "p", DefaultEnvPrefix, "Environment Variable Configuration Prefix")
 	flag.StringVarP(&flag.ConfigFile, "config", "c", "/opt/homebrew/etc/"+Binary+".conf", "Config File")
 	flag.BoolVarP(&flag.VersionReq, "version", "v", false, "Print the version and exit")
+	flag.BoolVar(&flag.StartReq, "start", false, "Start the LaunchAgent (macOS)")
+	flag.BoolVar(&flag.StopReq, "stop", false, "Stop the LaunchAgent (macOS)")
+	flag.BoolVar(&flag.RestartReq, "restart", false, "Restart the LaunchAgent (macOS)")
 	_ = flag.Parse(args) // flag.ExitOnError means this will never return != nil
+}
+
+// serviceAction returns the requested LaunchAgent action, if any.
+func (flag *Flags) serviceAction() (service.Action, error) {
+	count := 0
+	var action service.Action
+
+	if flag.StartReq {
+		count++
+		action = service.Start
+	}
+
+	if flag.StopReq {
+		count++
+		action = service.Stop
+	}
+
+	if flag.RestartReq {
+		count++
+		action = service.Restart
+	}
+
+	if count == 0 {
+		return "", nil
+	}
+
+	if count > 1 {
+		return "", ErrMultipleServiceFlags
+	}
+
+	return action, nil
 }
 
 // Start the daemon.
@@ -114,7 +157,21 @@ func Start() error {
 		return nil                         // don't run anything else w/ version request.
 	}
 
-	err := app.ParseConfigFile()
+	action, err := app.Flag.serviceAction()
+	if err != nil {
+		return err
+	}
+
+	if action != "" {
+		err := service.Run(action)
+		if err != nil {
+			return fmt.Errorf("service %s: %w", action, err)
+		}
+
+		return nil
+	}
+
+	err = app.ParseConfigFile()
 	if err != nil {
 		app.Flag.Usage()
 		return err

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,33 @@
+// Package service controls the Motifini background service (LaunchAgent on macOS).
+package service
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Action is a service control operation.
+type Action string
+
+// Supported service control actions.
+const (
+	Start   Action = "start"
+	Stop    Action = "stop"
+	Restart Action = "restart"
+)
+
+// Label is the LaunchAgent / service identifier.
+const Label = "io.golift.motifini"
+
+// ErrUnknownAction is returned when Run is given an unsupported action.
+var ErrUnknownAction = errors.New("unknown service action")
+
+// Run executes a service control action for the current platform.
+func Run(action Action) error {
+	switch action {
+	case Start, Stop, Restart:
+		return run(action)
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownAction, action)
+	}
+}

--- a/pkg/service/service_macos.go
+++ b/pkg/service/service_macos.go
@@ -1,0 +1,67 @@
+//go:build darwin
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const launchctlTimeout = 30 * time.Second
+
+// Supported reports whether service control is available on this platform.
+func Supported() bool { return true }
+
+func run(action Action) error {
+	uid := strconv.Itoa(os.Getuid())
+	domain := "gui/" + uid
+	service := domain + "/" + Label
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home directory: %w", err)
+	}
+
+	plist := filepath.Join(home, "Library", "LaunchAgents", Label+".plist")
+	args := launchctlArgs(action, domain, service, plist)
+
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+
+	//nolint:gosec // fixed launchctl binary; args are uid/plist paths we build
+	cmd := exec.CommandContext(ctx, "launchctl", args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if msg == "" {
+			return fmt.Errorf("launchctl %s: %w", action, err)
+		}
+
+		return fmt.Errorf("launchctl %s: %w: %s", action, err, msg)
+	}
+
+	if len(out) > 0 {
+		fmt.Print(string(out)) //nolint:forbidigo // surface launchctl stdout
+	}
+
+	fmt.Printf("%s %s\n", Label, action) //nolint:forbidigo // cli status
+
+	return nil
+}
+
+func launchctlArgs(action Action, domain, service, plist string) []string {
+	switch action {
+	case Start:
+		return []string{"bootstrap", domain, plist}
+	case Stop:
+		return []string{"bootout", service}
+	default: // Restart (validated by Run)
+		return []string{"kickstart", "-k", service}
+	}
+}

--- a/pkg/service/service_macos_test.go
+++ b/pkg/service/service_macos_test.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSupported(t *testing.T) {
+	t.Parallel()
+
+	if !Supported() {
+		t.Fatal("expected Supported on darwin")
+	}
+}
+
+func TestRunUnknownAction(t *testing.T) {
+	t.Parallel()
+
+	err := Run(Action("nope"))
+	if !errors.Is(err, ErrUnknownAction) {
+		t.Fatalf("got %v want %v", err, ErrUnknownAction)
+	}
+}

--- a/pkg/service/service_other.go
+++ b/pkg/service/service_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package service
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnsupported is returned when service control is unavailable on this OS.
+var ErrUnsupported = errors.New("service control is only supported on macOS at this time")
+
+// Supported reports whether service control is available on this platform.
+func Supported() bool { return false }
+
+func run(action Action) error {
+	return fmt.Errorf("%w (%s)", ErrUnsupported, action)
+}

--- a/pkg/service/service_other_test.go
+++ b/pkg/service/service_other_test.go
@@ -1,0 +1,25 @@
+//go:build !darwin
+
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSupported(t *testing.T) {
+	t.Parallel()
+
+	if Supported() {
+		t.Fatal("expected Supported false off darwin")
+	}
+}
+
+func TestRunUnsupported(t *testing.T) {
+	t.Parallel()
+
+	err := Run(Start)
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("got %v want %v", err, ErrUnsupported)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `motifini --start`, `--stop`, and `--restart` (macOS only) to control the Homebrew LaunchAgent via `launchctl`
- New `pkg/service` with darwin/`!darwin` build-tagged implementations for future OS support
- Document the new flags in the README

## Test plan
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] `motifini --start` bootstraps `gui/$(id -u)/io.golift.motifini`
- [ ] `motifini --restart` kickstarts the agent
- [ ] `motifini --stop` boots it out
- [ ] Passing more than one of the three flags errors
- [ ] Non-macOS builds report unsupported

