### PR TITLE
Address Copilot follow-ups from #16 and #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ motifini --restart  # restart the running agent
 motifini --stop     # unload / stop
 ```
 
-These wrap the same `launchctl` calls (`bootstrap` / `kickstart -k` / `bootout` for
-`gui/$(id -u)/io.golift.motifini`). `brew services` only manages formulae, not casks.
+These wrap:
+
+- `--start` → `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.golift.motifini.plist`
+- `--restart` → `launchctl kickstart -k gui/$(id -u)/io.golift.motifini`
+- `--stop` → `launchctl bootout gui/$(id -u)/io.golift.motifini`
+
+`brew services` only manages formulae, not casks.
 
 The example config defaults to Apple Silicon Homebrew paths under `/opt/homebrew`
 (`state_file`, `log_file`, `event_log`). If `brew --prefix` is `/usr/local` (Intel)
@@ -84,7 +89,7 @@ Every allowed chat has its own settings. One person can watch the driveway for c
 
 **Per-camera clip settings** (admins — `/camset` or Cams → camera → Clip settings)
 
-Clip quality is shared for that camera (motion alerts and `/vid`): scale (full / half / third / quarter), length (2–15s), and max size (500k–3MB). Half requests slightly under half native height so SecuritySpy recompresses HEVC instead of stream-copying the full frame.
+Clip quality is shared for that camera (motion alerts and `/vid`): scale (full / half / third / quarter), length (2–15s), max size (500k–3MB), and output codec (h265 default / h264 / auto). Half requests slightly under half native height so SecuritySpy recompresses HEVC instead of stream-copying the full frame.
 
 **Built-in system events** (subscribe like any other event)
 

--- a/pkg/chat/commands_nonadmin.go
+++ b/pkg/chat/commands_nonadmin.go
@@ -54,7 +54,7 @@ func (c *Chat) nonAdminCommands() *Commands { //nolint:funlen // it's not that b
 			{
 				Run:  c.cmdUnsub,
 				AKA:  []string{"unsub", "unsung", "unsubscribe", "unsure", "unseen"},
-				Use:  "[cam|event|camera:class]",
+				Use:  "[camera class|event|camera:class]",
 				Desc: "Unsubscribe via menu, or text: /unsub Office · /unsub Office human",
 				Save: true,
 			},

--- a/pkg/chat/commands_nonadmin.go
+++ b/pkg/chat/commands_nonadmin.go
@@ -54,7 +54,7 @@ func (c *Chat) nonAdminCommands() *Commands { //nolint:funlen // it's not that b
 			{
 				Run:  c.cmdUnsub,
 				AKA:  []string{"unsub", "unsung", "unsubscribe", "unsure", "unseen"},
-				Use:  "[cam|event|*]",
+				Use:  "[cam|event|camera:class]",
 				Desc: "Unsubscribe via menu, or text: /unsub Office · /unsub Office human",
 				Save: true,
 			},

--- a/pkg/service/service_macos_test.go
+++ b/pkg/service/service_macos_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -21,5 +22,31 @@ func TestRunUnknownAction(t *testing.T) {
 	err := Run(Action("nope"))
 	if !errors.Is(err, ErrUnknownAction) {
 		t.Fatalf("got %v want %v", err, ErrUnknownAction)
+	}
+}
+
+func TestLaunchctlArgs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		domain  = "gui/501"
+		service = "gui/501/io.golift.motifini"
+		plist   = "/Users/test/Library/LaunchAgents/io.golift.motifini.plist"
+	)
+
+	cases := []struct {
+		action Action
+		want   []string
+	}{
+		{Start, []string{"bootstrap", domain, plist}},
+		{Stop, []string{"bootout", service}},
+		{Restart, []string{"kickstart", "-k", service}},
+	}
+
+	for _, tc := range cases {
+		got := launchctlArgs(tc.action, domain, service, plist)
+		if !slices.Equal(got, tc.want) {
+			t.Fatalf("%s: got %v want %v", tc.action, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- README: document per-camera output codec; list exact `launchctl` commands for `--start`/`--restart`/`--stop`
- `/unsub` usage string no longer advertises the removed `*` shortcut
- Add `launchctlArgs` unit test covering bootstrap / bootout / kickstart mappings

## Test plan
- [x] `golangci-lint run ./...`
- [x] `go test ./...`

