### PR TITLE
Admin manage subscriptions from /users

### DIFF
--- a/pkg/chat/wizard_admin.go
+++ b/pkg/chat/wizard_admin.go
@@ -88,6 +88,7 @@ func (c *Chat) usersWizardItem(handler *Handler, idStr string) *Reply {
 	}
 
 	rows = append(rows,
+		[]Button{{Label: "Manage subscriptions", Data: fmt.Sprintf("m:subs:%d", target.ID)}},
 		[]Button{{Label: "Rename…", Data: fmt.Sprintf("m:rename:%d", target.ID)}},
 		[]Button{{Label: "Delete…", Data: fmt.Sprintf("m:del:%d", target.ID)}},
 		[]Button{

--- a/pkg/chat/wizard_admin_subs.go
+++ b/pkg/chat/wizard_admin_subs.go
@@ -1,0 +1,435 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"golift.io/subscribe"
+)
+
+// Admin manage-another-user's-subscriptions wizard (under /users, Telegram ≤64 bytes).
+//
+// m:subs:{uid}              → list target's subscriptions
+// m:si:{uid}:{idx}          → manage one subscription
+// m:sp:{uid}:{mins}:{idx}   → pause / clear pause
+// m:sd:{uid}:{idx}          → delay presets
+// m:sda:{uid}:{idx}:{secs}  → apply delay
+// m:su:{uid}:{idx}          → unsubscribe
+// m:ss:{uid}                → subscribe: pick trigger class
+// m:ss:{uid}:{class}        → subscribe: pick camera
+// m:ssa:{uid}:{class}:{idx} → subscribe: apply
+
+func (c *Chat) adminSubsWizardRoot(handler *Handler, idStr string) *Reply {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone()
+	}
+
+	names := targetEventNames(target)
+	display := subscriberDisplayName(target)
+
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "Subscriptions for %s (%d).\n\n", display, len(names))
+	msg.WriteString("Tap one to pause, change delay, or unsubscribe.\n")
+
+	rows := make([][]Button, 0, len(names)+2)
+	for idx, event := range names {
+		line := formatSubLabel(event)
+		fmt.Fprintf(&msg, "\n• %s · every %s", line, formatDuration(eventDelay(target.Events, event)))
+		if target.Events.IsPaused(event) {
+			until := time.Until(target.Events.PauseTime(event))
+			fmt.Fprintf(&msg, " (paused %s)", formatDuration(until))
+		}
+		rows = append(rows, []Button{{
+			Label: line,
+			Data:  fmt.Sprintf("m:si:%d:%d", target.ID, idx),
+		}})
+	}
+
+	if len(names) == 0 {
+		msg.WriteString("\n(none yet)")
+	}
+
+	rows = append(rows,
+		[]Button{{Label: "Subscribe for them", Data: fmt.Sprintf("m:ss:%d", target.ID)}},
+		[]Button{
+			{Label: "« User", Data: fmt.Sprintf("m:i:%d", target.ID)},
+			{Label: "Done", Data: cbCancel},
+		},
+	)
+
+	return &Reply{Reply: msg.String(), Edit: true, Keyboard: rows}
+}
+
+func (c *Chat) adminSubsWizardItem(handler *Handler, payload string) *Reply {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply
+	}
+
+	idStr, idxStr, found := strings.Cut(payload, ":")
+	if !found {
+		return &Reply{Reply: "Bad pick.", Edit: true, Toast: "Error"}
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone()
+	}
+
+	idx := atoiDefault(idxStr, -1)
+	names := targetEventNames(target)
+	if idx < 0 || idx >= len(names) {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}
+	}
+
+	event := names[idx]
+	label := formatSubLabel(event)
+	uid := target.ID
+
+	return &Reply{
+		Reply: fmt.Sprintf("Manage %s for %s\n\n"+
+			"Pause = silence this subscription for a while.\n"+
+			"Set delay = how often clips may arrive.\n"+
+			"Unsubscribe = remove this subscription.",
+			label, subscriberDisplayName(target)),
+		Edit: true,
+		Keyboard: [][]Button{
+			{
+				{Label: "Pause 10m", Data: fmt.Sprintf("m:sp:%d:10:%d", uid, idx)},
+				{Label: "Clear pause", Data: fmt.Sprintf("m:sp:%d:0:%d", uid, idx)},
+			},
+			{
+				{Label: "Set delay", Data: fmt.Sprintf("m:sd:%d:%d", uid, idx)},
+				{Label: "Unsubscribe", Data: fmt.Sprintf("m:su:%d:%d", uid, idx)},
+			},
+			{
+				{Label: "« Subs", Data: fmt.Sprintf("m:subs:%d", uid)},
+				{Label: "Done", Data: cbCancel},
+			},
+		},
+	}
+}
+
+func (c *Chat) adminSubsWizardPause(handler *Handler, payload string) (*Reply, bool) {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply, false
+	}
+
+	idStr, rest, found := strings.Cut(payload, ":")
+	if !found {
+		return &Reply{Reply: "Bad pause pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	minsStr, idxStr, found := strings.Cut(rest, ":")
+	if !found {
+		return &Reply{Reply: "Bad pause pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone(), false
+	}
+
+	mins := atoiDefault(minsStr, 10)
+	idx := atoiDefault(idxStr, -1)
+	names := targetEventNames(target)
+	if idx < 0 || idx >= len(names) {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}, false
+	}
+
+	event := names[idx]
+	_ = target.Events.Pause(event, time.Duration(mins)*time.Minute)
+
+	msg := fmt.Sprintf("Paused %s for %s (%d min).",
+		formatSubLabel(event), subscriberDisplayName(target), mins)
+	if mins == 0 {
+		msg = fmt.Sprintf("Cleared pause on %s for %s.",
+			formatSubLabel(event), subscriberDisplayName(target))
+	}
+
+	next := c.adminSubsWizardRoot(handler, idStr)
+	next.Reply = msg + "\n\n" + next.Reply
+	next.Toast = "Saved"
+
+	return next, true
+}
+
+func (c *Chat) adminSubsWizardDelayPick(handler *Handler, payload string) *Reply {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply
+	}
+
+	idStr, idxStr, found := strings.Cut(payload, ":")
+	if !found {
+		return &Reply{Reply: "Bad delay pick.", Edit: true, Toast: "Error"}
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone()
+	}
+
+	idx := atoiDefault(idxStr, -1)
+	names := targetEventNames(target)
+	if idx < 0 || idx >= len(names) {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}
+	}
+
+	uid := target.ID
+
+	return &Reply{
+		Reply: fmt.Sprintf("Repeat delay for %s (%s).",
+			formatSubLabel(names[idx]), subscriberDisplayName(target)),
+		Edit: true,
+		Keyboard: [][]Button{
+			{
+				{Label: "15s", Data: fmt.Sprintf("m:sda:%d:%d:15", uid, idx)},
+				{Label: "30s", Data: fmt.Sprintf("m:sda:%d:%d:30", uid, idx)},
+				{Label: "60s", Data: fmt.Sprintf("m:sda:%d:%d:60", uid, idx)},
+			},
+			{
+				{Label: "2 min", Data: fmt.Sprintf("m:sda:%d:%d:120", uid, idx)},
+				{Label: "5 min", Data: fmt.Sprintf("m:sda:%d:%d:300", uid, idx)},
+				{Label: "10 min", Data: fmt.Sprintf("m:sda:%d:%d:600", uid, idx)},
+			},
+			{
+				{Label: "« Back", Data: fmt.Sprintf("m:si:%d:%d", uid, idx)},
+				{Label: "Done", Data: cbCancel},
+			},
+		},
+	}
+}
+
+func (c *Chat) adminSubsWizardDelayApply(handler *Handler, payload string) (*Reply, bool) {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply, false
+	}
+
+	parts := strings.Split(payload, ":")
+	if len(parts) != 3 {
+		return &Reply{Reply: "Bad delay pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	target, err := c.adminTargetByID(handler.API, parts[0])
+	if err != nil {
+		return c.adminTargetGone(), false
+	}
+
+	idx := atoiDefault(parts[1], -1)
+	secs := atoiDefault(parts[2], 60)
+	names := targetEventNames(target)
+	if idx < 0 || idx >= len(names) {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}, false
+	}
+
+	event := names[idx]
+	target.Events.RuleSetD(event, "delay", time.Duration(secs)*time.Second)
+
+	next := c.adminSubsWizardRoot(handler, parts[0])
+	next.Reply = fmt.Sprintf("Delay for %s set to %s.\n\n",
+		formatSubLabel(event), formatDuration(time.Duration(secs)*time.Second)) + next.Reply
+	next.Toast = "Saved"
+
+	return next, true
+}
+
+func (c *Chat) adminSubsWizardUnsub(handler *Handler, payload string) (*Reply, bool) {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply, false
+	}
+
+	idStr, idxStr, found := strings.Cut(payload, ":")
+	if !found {
+		return &Reply{Reply: "Bad pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone(), false
+	}
+
+	idx := atoiDefault(idxStr, -1)
+	names := targetEventNames(target)
+	if idx < 0 || idx >= len(names) {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}, false
+	}
+
+	event := names[idx]
+	target.Events.Remove(event)
+
+	next := c.adminSubsWizardRoot(handler, idStr)
+	next.Reply = fmt.Sprintf("Unsubscribed %s from %s.\n\n",
+		subscriberDisplayName(target), formatSubLabel(event)) + next.Reply
+	next.Toast = "Removed"
+
+	return next, true
+}
+
+func (c *Chat) adminSubsWizardSubClass(handler *Handler, idStr string) *Reply {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone()
+	}
+
+	uid := target.ID
+
+	return &Reply{
+		Reply: fmt.Sprintf("Subscribe %s — which trigger?", subscriberDisplayName(target)),
+		Edit:  true,
+		Keyboard: [][]Button{
+			{
+				{Label: "Motion", Data: fmt.Sprintf("m:ss:%d:%s", uid, classShort(ClassMotion))},
+				{Label: "Human", Data: fmt.Sprintf("m:ss:%d:%s", uid, classShort(ClassHuman))},
+			},
+			{
+				{Label: "Vehicle", Data: fmt.Sprintf("m:ss:%d:%s", uid, classShort(ClassVehicle))},
+				{Label: "Animal", Data: fmt.Sprintf("m:ss:%d:%s", uid, classShort(ClassAnimal))},
+			},
+			{
+				{Label: "« Subs", Data: fmt.Sprintf("m:subs:%d", uid)},
+				{Label: "Done", Data: cbCancel},
+			},
+		},
+	}
+}
+
+func (c *Chat) adminSubsWizardSubCameras(handler *Handler, payload string) *Reply {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply
+	}
+
+	idStr, classShortCode, found := strings.Cut(payload, ":")
+	if !found {
+		return &Reply{Reply: "Bad pick.", Edit: true, Toast: "Error"}
+	}
+
+	target, err := c.adminTargetByID(handler.API, idStr)
+	if err != nil {
+		return c.adminTargetGone()
+	}
+
+	class := classFromShort(classShortCode)
+	if class == ClassAny {
+		return c.adminSubsWizardSubClass(handler, idStr)
+	}
+
+	cams := c.allCameras()
+	if len(cams) == 0 {
+		return c.noCamerasReply()
+	}
+
+	uid := target.ID
+	rows := make([][]Button, 0, len(cams)/2+2)
+	row := make([]Button, 0, 2)
+
+	for camIdx, cam := range cams {
+		label := cam.Name
+		if badges := cameraSubBadges(target, cam.Name); badges != "" {
+			label += " " + badges
+		}
+		if !cam.Connected.Val {
+			label += " ⚠"
+		}
+		row = append(row, Button{
+			Label: label,
+			Data:  fmt.Sprintf("m:ssa:%d:%s:%d", uid, classShort(class), camIdx),
+		})
+		if len(row) == 2 {
+			rows = append(rows, row)
+			row = nil
+		}
+	}
+	if len(row) > 0 {
+		rows = append(rows, row)
+	}
+
+	rows = append(rows, []Button{
+		{Label: "« Back", Data: fmt.Sprintf("m:ss:%d", uid)},
+		{Label: "Done", Data: cbCancel},
+	})
+
+	return &Reply{
+		Reply: fmt.Sprintf("Pick a camera for %s alerts for %s.",
+			strings.ToLower(classLabel(class)), subscriberDisplayName(target)),
+		Edit:     true,
+		Keyboard: rows,
+	}
+}
+
+func (c *Chat) adminSubsWizardSubApply(handler *Handler, payload string) (*Reply, bool) {
+	if reply := c.requireAdmin(handler); reply != nil {
+		return reply, false
+	}
+
+	parts := strings.Split(payload, ":")
+	if len(parts) != 3 {
+		return &Reply{Reply: "Bad camera pick.", Edit: true, Toast: "Error"}, false
+	}
+
+	target, err := c.adminTargetByID(handler.API, parts[0])
+	if err != nil {
+		return c.adminTargetGone(), false
+	}
+
+	class := classFromShort(parts[1])
+	if class == ClassAny {
+		return c.adminSubsWizardSubClass(handler, parts[0]), false
+	}
+
+	camIdx := atoiDefault(parts[2], -1)
+	cams := c.allCameras()
+	if camIdx < 0 || camIdx >= len(cams) {
+		return &Reply{Reply: "Camera gone — try again.", Edit: true, Toast: "Missing"}, false
+	}
+
+	cam := cams[camIdx]
+	key := CameraSubKey(cam.Name, class)
+	toast := "Subscribed ✓"
+	msg := fmt.Sprintf("Subscribed %s to %s (%s).",
+		subscriberDisplayName(target), cam.Name, classLabel(class))
+
+	err = target.Subscribe(key)
+	if err != nil {
+		msg = fmt.Sprintf("%s already has %s (%s).",
+			subscriberDisplayName(target), cam.Name, classLabel(class))
+		toast = "Already on"
+	}
+
+	next := c.adminSubsWizardSubCameras(handler, parts[0]+":"+parts[1])
+	next.Reply = msg + "\n\n" + next.Reply
+	next.Toast = toast
+
+	return next, true
+}
+
+func (c *Chat) requireAdmin(handler *Handler) *Reply {
+	if handler == nil || handler.Sub == nil || !handler.Sub.Admin {
+		return &Reply{Reply: "Admins only.", Edit: true, Toast: "Nope"}
+	}
+
+	return nil
+}
+
+func (c *Chat) adminTargetGone() *Reply {
+	return &Reply{
+		Reply: "Subscriber gone — try again.", Edit: true, Toast: "Missing",
+		Keyboard: [][]Button{{{Label: "« Users", Data: cbUsersRoot}}},
+	}
+}
+
+func targetEventNames(target *subscribe.Subscriber) []string {
+	if target == nil || target.Events == nil {
+		return nil
+	}
+
+	return target.Events.Names()
+}

--- a/pkg/chat/wizard_admin_subs.go
+++ b/pkg/chat/wizard_admin_subs.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -135,7 +136,15 @@ func (c *Chat) adminSubsWizardPause(handler *Handler, payload string) (*Reply, b
 		return c.adminTargetGone(), false
 	}
 
-	mins := atoiDefault(minsStr, 10)
+	mins, err := strconv.Atoi(minsStr)
+	if err != nil || mins < 0 || mins > MaxPauseMinutes {
+		return &Reply{
+			Reply: fmt.Sprintf("Pause must be 0–%d minutes (24 hours).", MaxPauseMinutes),
+			Edit:  true,
+			Toast: "Error",
+		}, false
+	}
+
 	idx := atoiDefault(idxStr, -1)
 	names := targetEventNames(target)
 	if idx < 0 || idx >= len(names) {
@@ -143,7 +152,10 @@ func (c *Chat) adminSubsWizardPause(handler *Handler, payload string) (*Reply, b
 	}
 
 	event := names[idx]
-	_ = target.Events.Pause(event, time.Duration(mins)*time.Minute)
+	err = target.Events.Pause(event, time.Duration(mins)*time.Minute)
+	if err != nil {
+		return &Reply{Reply: "Subscription gone.", Edit: true, Toast: "Missing"}, false
+	}
 
 	msg := fmt.Sprintf("Paused %s for %s (%d min).",
 		formatSubLabel(event), subscriberDisplayName(target), mins)

--- a/pkg/chat/wizard_admin_subs_test.go
+++ b/pkg/chat/wizard_admin_subs_test.go
@@ -1,0 +1,125 @@
+package chat
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"golift.io/subscribe"
+)
+
+func TestHandleAdminSubsClearsPendingRename(t *testing.T) {
+	t.Parallel()
+
+	admin, target, chat := adminSubsTestFixture(t)
+	ensureSubMeta(admin)[pendingRenameMetaKey] = target.ID
+
+	handler := &Handler{API: "telegram", Sub: admin}
+	reply, save, ok := chat.handleAdminSubsWizardCallback(handler, fmt.Sprintf("m:subs:%d", target.ID))
+	if !ok || reply == nil {
+		t.Fatalf("expected handled callback, ok=%v reply=%v", ok, reply)
+	}
+	if save {
+		t.Fatal("listing subs should not save")
+	}
+	if _, pending := pendingRenameID(admin); pending {
+		t.Fatal("pending rename should be cleared when entering manage-subs")
+	}
+}
+
+func TestAdminSubsWizardPauseValidatesMinutes(t *testing.T) {
+	t.Parallel()
+
+	admin, target, chat := adminSubsTestFixture(t)
+	handler := &Handler{API: "telegram", Sub: admin}
+	uid := target.ID
+
+	// Names() is sorted; Office:human is the only event → index 0.
+	reply, save := chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:nope:0", uid))
+	if save || reply == nil || reply.Toast != "Error" {
+		t.Fatalf("bad mins: save=%v toast=%q reply=%q", save, reply.Toast, reply.Reply)
+	}
+
+	reply, save = chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:-1:0", uid))
+	if save || reply.Toast != "Error" {
+		t.Fatalf("negative mins: save=%v toast=%q", save, reply.Toast)
+	}
+
+	reply, save = chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:%d:0", uid, MaxPauseMinutes+1))
+	if save || reply.Toast != "Error" {
+		t.Fatalf("too large mins: save=%v toast=%q", save, reply.Toast)
+	}
+
+	if target.Events.IsPaused("Office:human") {
+		t.Fatal("invalid pause must not change subscription")
+	}
+}
+
+func TestAdminSubsWizardPauseAppliesAndHandlesMissing(t *testing.T) {
+	t.Parallel()
+
+	admin, target, chat := adminSubsTestFixture(t)
+	handler := &Handler{API: "telegram", Sub: admin}
+	uid := target.ID
+
+	reply, save := chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:10:0", uid))
+	if !save || reply.Toast != "Saved" {
+		t.Fatalf("valid pause: save=%v toast=%q", save, reply.Toast)
+	}
+	if !target.Events.IsPaused("Office:human") {
+		t.Fatal("expected Office:human paused")
+	}
+
+	reply, save = chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:0:0", uid))
+	if !save || reply.Toast != "Saved" {
+		t.Fatalf("clear pause: save=%v toast=%q", save, reply.Toast)
+	}
+	// Pause(0) sets Pause=now; IsPaused is true only when Pause.After(now), so
+	// a just-cleared pause should not still count as paused.
+	if target.Events.IsPaused("Office:human") {
+		// Allow tiny clock skew: wait and re-check once.
+		time.Sleep(2 * time.Millisecond)
+		if target.Events.IsPaused("Office:human") {
+			t.Fatal("expected pause cleared")
+		}
+	}
+
+	// Stale index after the subscription is removed.
+	target.Events.Remove("Office:human")
+	reply, save = chat.adminSubsWizardPause(handler, fmt.Sprintf("%d:10:0", uid))
+	if save || reply.Toast != "Missing" {
+		t.Fatalf("missing sub: save=%v toast=%q", save, reply.Toast)
+	}
+}
+
+func adminSubsTestFixture(t *testing.T) (*subscribe.Subscriber, *subscribe.Subscriber, *Chat) {
+	t.Helper()
+
+	admin := &subscribe.Subscriber{
+		ID:      1,
+		API:     "telegram",
+		Contact: "Admin",
+		Admin:   true,
+		Meta:    map[string]any{},
+		Events:  &subscribe.Events{Map: make(map[string]*subscribe.Rules)},
+	}
+	target := &subscribe.Subscriber{
+		ID:      2,
+		API:     "telegram",
+		Contact: "Alice",
+		Events:  &subscribe.Events{Map: make(map[string]*subscribe.Rules)},
+	}
+	err := target.Subscribe("Office:human")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chat := &Chat{
+		Subs: &subscribe.Subscribe{
+			Subscribers: []*subscribe.Subscriber{admin, target},
+			Events:      &subscribe.Events{Map: make(map[string]*subscribe.Rules)},
+		},
+	}
+
+	return admin, target, chat
+}

--- a/pkg/chat/wizard_cmds.go
+++ b/pkg/chat/wizard_cmds.go
@@ -200,6 +200,15 @@ func (c *Chat) handleUsersWizardCallback(handler *Handler, data string) (*Reply,
 }
 
 func (c *Chat) handleAdminSubsWizardCallback(handler *Handler, data string) (*Reply, bool, bool) {
+	if !isAdminSubsCallback(data) {
+		return nil, false, false
+	}
+
+	// Cancel any in-progress rename prompt (same as m:i: / m: root).
+	if handler != nil {
+		clearPendingRename(handler.Sub)
+	}
+
 	switch {
 	case strings.HasPrefix(data, "m:sda:"):
 		reply, save := c.adminSubsWizardDelayApply(handler, strings.TrimPrefix(data, "m:sda:"))
@@ -233,6 +242,18 @@ func (c *Chat) handleAdminSubsWizardCallback(handler *Handler, data string) (*Re
 	default:
 		return nil, false, false
 	}
+}
+
+func isAdminSubsCallback(data string) bool {
+	for _, prefix := range []string{
+		"m:sda:", "m:sd:", "m:sp:", "m:su:", "m:ssa:", "m:ss:", "m:si:", "m:subs:",
+	} {
+		if strings.HasPrefix(data, prefix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func atoiDefault(s string, def int) int {

--- a/pkg/chat/wizard_cmds.go
+++ b/pkg/chat/wizard_cmds.go
@@ -149,6 +149,10 @@ func (c *Chat) handlePauseDelayWizardCallback(handler *Handler, data string) (*R
 }
 
 func (c *Chat) handleUsersWizardCallback(handler *Handler, data string) (*Reply, bool, bool) {
+	if reply, save, ok := c.handleAdminSubsWizardCallback(handler, data); ok {
+		return reply, save, true
+	}
+
 	switch {
 	case strings.HasPrefix(data, "m:rename:"):
 		return c.usersWizardRenamePrompt(handler, strings.TrimPrefix(data, "m:rename:")), true, true
@@ -190,6 +194,42 @@ func (c *Chat) handleUsersWizardCallback(handler *Handler, data string) (*Reply,
 		reply, save := c.usersWizardAction(handler, "admin", strings.TrimPrefix(data, "m:admin:"))
 
 		return reply, save, true
+	default:
+		return nil, false, false
+	}
+}
+
+func (c *Chat) handleAdminSubsWizardCallback(handler *Handler, data string) (*Reply, bool, bool) {
+	switch {
+	case strings.HasPrefix(data, "m:sda:"):
+		reply, save := c.adminSubsWizardDelayApply(handler, strings.TrimPrefix(data, "m:sda:"))
+
+		return reply, save, true
+	case strings.HasPrefix(data, "m:sd:"):
+		return c.adminSubsWizardDelayPick(handler, strings.TrimPrefix(data, "m:sd:")), false, true
+	case strings.HasPrefix(data, "m:sp:"):
+		reply, save := c.adminSubsWizardPause(handler, strings.TrimPrefix(data, "m:sp:"))
+
+		return reply, save, true
+	case strings.HasPrefix(data, "m:su:"):
+		reply, save := c.adminSubsWizardUnsub(handler, strings.TrimPrefix(data, "m:su:"))
+
+		return reply, save, true
+	case strings.HasPrefix(data, "m:ssa:"):
+		reply, save := c.adminSubsWizardSubApply(handler, strings.TrimPrefix(data, "m:ssa:"))
+
+		return reply, save, true
+	case strings.HasPrefix(data, "m:ss:"):
+		payload := strings.TrimPrefix(data, "m:ss:")
+		if strings.Contains(payload, ":") {
+			return c.adminSubsWizardSubCameras(handler, payload), false, true
+		}
+
+		return c.adminSubsWizardSubClass(handler, payload), false, true
+	case strings.HasPrefix(data, "m:si:"):
+		return c.adminSubsWizardItem(handler, strings.TrimPrefix(data, "m:si:")), false, true
+	case strings.HasPrefix(data, "m:subs:"):
+		return c.adminSubsWizardRoot(handler, strings.TrimPrefix(data, "m:subs:")), false, true
 	default:
 		return nil, false, false
 	}
@@ -946,6 +986,9 @@ func (c *Chat) subsWizardRoot(handler *Handler) *Reply {
 	var msg strings.Builder
 	msg.WriteString("Your alert subscriptions.\n\n")
 	msg.WriteString("Tap a subscription below to pause it, change how often clips arrive, or remove it.\n")
+	if handler.Sub != nil && handler.Sub.Admin {
+		msg.WriteString("\nAdmin tip: use /users → person → Manage subscriptions to edit someone else's.\n")
+	}
 
 	if len(names) == 0 {
 		msg.WriteString("\n(none yet — use Subscribe to start)")
@@ -1052,7 +1095,7 @@ func (c *Chat) helpWizardRootFor(handler *Handler) *Reply {
 				root.Keyboard = rows
 			}
 		}
-		root.Reply += "\n• Users (admin) — allow/deny/ignore/admin/delete subscribers" +
+		root.Reply += "\n• Users (admin) — allow/deny/ignore/admin/delete subscribers; manage their subscriptions" +
 			"\n• Clip set (admin) — per-camera scale / length / size for everyone"
 	}
 


### PR DESCRIPTION
## Summary
- `/users` → person → **Manage subscriptions** lets admins list, pause, set delay, unsubscribe, and subscribe on behalf of another user
- `/subs` shows an admin tip to use `/users` for managing other people's subscriptions
- Help text for Users mentions subscription management

## Test plan
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] As admin: `/users` → pick user → Manage subscriptions → pause / delay / unsubscribe
- [ ] Subscribe for them (class → camera) updates badges / list
- [ ] `/subs` as admin shows the tip about `/users`
- [ ] Non-admin cannot open manage-subscriptions callbacks
